### PR TITLE
Fixing an issue where pages did not contain the expected content

### DIFF
--- a/cursorpaging-examples/webapp-with-maven/pom.xml
+++ b/cursorpaging-examples/webapp-with-maven/pom.xml
@@ -20,7 +20,7 @@
     <java.version>17</java.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <lombok.version>1.18.32</lombok.version>
-    <cursorpage.version>0.8.0</cursorpage.version>
+    <cursorpage.version>0.8.1</cursorpage.version>
     <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
@@ -82,9 +82,9 @@ public class Filter {
      */
     public void apply( final QueryBuilder qb ) {
         if ( values.size() > 1 ) {
-            qb.isIn( attribute, values );
+            qb.addWhere( qb.isIn( attribute, values ) );
         } else {
-            qb.isEqual( attribute, values.get( 0 ) );
+            qb.addWhere( qb.equalTo( attribute, values.get( 0 ) ) );
         }
     }
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Position.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Position.java
@@ -1,11 +1,15 @@
 package io.vigier.cursorpaging.jpa;
 
+import jakarta.persistence.criteria.Predicate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * A position, which can be used to address the start of a page.
@@ -18,6 +22,7 @@ import lombok.experimental.Accessors;
 @Accessors( fluent = true )
 @EqualsAndHashCode
 @ToString
+@Slf4j
 public class Position {
 
     /**
@@ -60,16 +65,25 @@ public class Position {
     /**
      * Will apply the position information to the given {@link QueryBuilder}.
      *
-     * @param qb builder where position information will be applied.
+     * @param qb             builder where position information will be applied.
+     * @param preconditions preconditions to apply.
      */
-    public void apply( final QueryBuilder qb ) {
+    public void apply( final QueryBuilder qb, final List<Predicate> preconditions ) {
+        log.debug( "Position.apply ({} = {}, order = {})", attribute.name(), value, order );
         if ( !isFirst() ) {
             switch ( order ) {
-                case ASC -> qb.greaterThan( attribute, value );
-                case DESC -> qb.lessThan( attribute, value );
+                case ASC -> qb.addWhere( add( qb.greaterThan( attribute, value ), preconditions ) );
+                case DESC -> qb.addWhere( add( qb.lessThan( attribute, value ), preconditions ) );
             }
         }
         qb.orderBy( attribute, order );
+    }
+
+    private List<Predicate> add( final Predicate condition, final List<Predicate> preconditions ) {
+        final List<Predicate> all = new ArrayList<>( preconditions.size() + 1 );
+        all.addAll( preconditions );
+        all.add( condition );
+        return all;
     }
 
     /**
@@ -81,5 +95,9 @@ public class Position {
     public Position positionOf( final Object entity ) {
         return toBuilder().value( attribute.valueOf( entity ) )
                 .build();
+    }
+
+    public Predicate getEquals( final QueryBuilder cqb ) {
+        return cqb.equalTo( attribute, value );
     }
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
@@ -6,28 +6,13 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Queries required by the cursor paging.
  *
  */
 public interface QueryBuilder {
-
-    /**
-     * In case of descending order the positions are less than the last one on the previous page.
-     *
-     * @param attribute the attribute to use for the query
-     * @param value     the value to use for the query
-     */
-    void lessThan( Attribute attribute, Comparable<?> value );
-
-    /**
-     * In case of ascending order the positions are greater than on the previous page
-     *
-     * @param attribute the attribute to use for the query
-     * @param value     the value to use for the query
-     */
-    void greaterThan( Attribute attribute, Comparable<?> value );
 
     /**
      * Provide the order for the position query
@@ -41,24 +26,19 @@ public interface QueryBuilder {
      * Used to filter out not matching entities
      *
      * @param attribute the attribute to filter on
-     * @param value the value to filter on
+     * @param value     the value to filter on
+     * @return the predicate to add to the query
      */
-    void isIn( Attribute attribute, Collection<? extends Comparable<?>> value );
-
-    /**
-     * Used to filter out not matching entities
-     *
-     * @param attribute the attribute to filter on
-     * @param value the value to filter on
-     */
-    void isEqual( Attribute attribute, Comparable<?> value );
+    Predicate isIn( Attribute attribute, Collection<? extends Comparable<?>> value );
 
     /**
      * Low level access to add custom filter rules
      *
-     * @param predicate
+     * @param predicate the predicate to add
      */
     void addWhere( final Predicate predicate );
+
+    void addWhere( final List<Predicate> predicate );
 
     /**
      * Low level access to the query for the root-entity
@@ -89,4 +69,31 @@ public interface QueryBuilder {
      * @return the entity manager
      */
     EntityManager entityManager();
+
+    /**
+     * Get an equal predicate for the given attribute and value
+     *
+     * @param attribute the attribute
+     * @param value     the value to be compared
+     * @return the predicate which can be added to the query
+     */
+    Predicate equalTo( Attribute attribute, Comparable<?> value );
+
+    /**
+     * Get a greater than predicate for the given attribute and value
+     *
+     * @param attribute the attribute
+     * @param value     the value to be compared
+     * @return the predicate which can be added to the query
+     */
+    Predicate greaterThan( Attribute attribute, Comparable<?> value );
+
+    /**
+     * Get a less than predicate for the given attribute and value
+     *
+     * @param attribute the attribute
+     * @param value     the value to be compared
+     * @return the predicate which can be added to the query
+     */
+    Predicate lessThan( final Attribute attribute, final Comparable<?> value );
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
@@ -5,6 +5,8 @@ import io.vigier.cursorpaging.jpa.Page;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.repository.CursorPageRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.Predicate;
+import java.util.LinkedList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
@@ -49,7 +51,11 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
         final CriteriaQueryBuilder<E, E> cqb = CriteriaQueryBuilder.forEntity( entityInformation.getJavaType(),
                 entityManager );
 
-        request.positions().forEach( position -> position.apply( cqb ) );
+        final List<Predicate> positionEquals = new LinkedList<>();
+        request.positions().forEach( position -> {
+            position.apply( cqb.orCondition(), positionEquals );
+            positionEquals.add( position.getEquals( cqb ) );
+        } );
         request.filters().forEach( filter -> filter.apply( cqb ) );
         request.rules().forEach( rule -> rule.applyQuery( cqb ) );
 

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
@@ -1,0 +1,87 @@
+package io.vigier.cursorpaging.jpa.itest;
+
+import io.vigier.cursorpaging.jpa.itest.model.AuditInfo;
+import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
+import io.vigier.cursorpaging.jpa.itest.model.SecurityClass;
+import io.vigier.cursorpaging.jpa.itest.repository.AccessEntryRepository;
+import io.vigier.cursorpaging.jpa.itest.repository.DataRecordRepository;
+import io.vigier.cursorpaging.jpa.itest.repository.SecurityClassRepository;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static io.vigier.cursorpaging.jpa.itest.model.AccessEntry.Action.READ;
+import static io.vigier.cursorpaging.jpa.itest.model.AccessEntry.Action.WRITE;
+
+@Service
+@Slf4j
+public class TestDataGenerator {
+
+    public static final String[] NAMES = { "Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Hotel",
+            "India", "Juliett", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo", "Sierra",
+            "Tango", "Uniform", "Victor", "Whiskey", "X-ray", "Yankee", "Zulu" };
+    public static final String SUBJECT_READ_STANDARD = "read_standard";
+    public static final String SUBJECT_READ_SENSITIVE = "read_sensitive";
+    public static final String SUBJECT_WRITE_SENSITIVE = "write_sensitive";
+
+    @Autowired
+    private DataRecordRepository dataRecordRepository;
+    @Autowired
+    private AccessEntryRepository accessEntryRepository;
+    @Autowired
+    private SecurityClassRepository securityClassRepository;
+
+    List<DataRecord> generateData( final int count ) {
+        deleteAll();
+
+        securityClassRepository.save( SecurityClass.builder().level( 0 ).name( "public" )
+                .build() );
+        final SecurityClass cl1 = securityClassRepository.save( SecurityClass.builder().level( 1 ).name( "standard" )
+                .build() );
+        final SecurityClass cl2 = securityClassRepository.save(
+                SecurityClass.builder().level( 2 ).name( "confidential" )
+                        .build() );
+
+        accessEntryRepository.saveEntry( b -> b.subject( SUBJECT_READ_STANDARD ).action( READ ).securityClass( cl1 ) );
+        accessEntryRepository.saveEntry( b -> b.subject( SUBJECT_READ_SENSITIVE ).action( READ ).securityClass( cl2 ) );
+        accessEntryRepository.saveEntry(
+                b -> b.subject( SUBJECT_WRITE_SENSITIVE ).action( WRITE ).securityClass( cl2 ) );
+
+        return generateDataRecords( count );
+    }
+
+    private void deleteAll() {
+        accessEntryRepository.deleteAll();
+        dataRecordRepository.deleteAll();
+        securityClassRepository.deleteAll();
+        accessEntryRepository.flush();
+        dataRecordRepository.flush();
+        securityClassRepository.flush();
+    }
+
+    public List<DataRecord> generateDataRecords( final int count ) {
+
+        final SecurityClass[] securityClasses = securityClassRepository.findAll().toArray( SecurityClass[]::new );
+
+        Instant created = Instant.parse( "1999-01-02T10:15:30.00Z" );
+        final List<DataRecord> allRecords = new ArrayList<>( count );
+        for ( int i = 0; i < count; i++ ) {
+            created = created.plus( 1, ChronoUnit.DAYS );
+            allRecords.add( dataRecordRepository.save( DataRecord.builder()
+                    .name( nextName( i ) )
+                    .securityClass( securityClasses[i % securityClasses.length] )
+                    .auditInfo( AuditInfo.create( created, created.plus( 10, ChronoUnit.MINUTES ) ) )
+                    .build() ) );
+        }
+        log.info( "Generated {} test data-records", dataRecordRepository.count() );
+        return allRecords;
+    }
+
+    private String nextName( final int i ) {
+        return NAMES[i % NAMES.length];
+    }
+}


### PR DESCRIPTION
When using multiple and not-unique attributes as cursor properties, the query was build up with only "and" statements, resulting in incorrect page content (dummy code for selecting a certain page):
```
select * from datarecord 
 where name > 'Echo' and id > '1234-5678-90123'
```
Query is now build with an hierarchical strategy:
```
select * from datarecord
 where name > 'Echo'
       or (name = 'Echo' and id > '1234-5678-90123')
```