### PR TITLE
Fix issue where filter by enum-attribute causes a "cannot cast to tiny int exception"

### DIFF
--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Attribute.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Attribute.java
@@ -109,10 +109,12 @@ public record Attribute( @Singular List<SingleAttribute> attributes ) {
      */
     public <E, V extends Comparable<? super V>> Expression<V> path( final Root<E> root ) {
         Path<?> path = root;
+        String name = "";
         for ( final SingleAttribute a : attributes ) {
-            path = path.get( a.name() );
+            name = a.name();
+            path = path.get( name );
         }
-        return path.as( this.<V>type() );
+        return path.getParentPath().get( name );
     }
 
     /**

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
@@ -4,6 +4,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.metamodel.SingularAttribute;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -92,20 +93,55 @@ public class Filter {
     }
 
     /**
-     * Create a {@linkplain Filter} with the given attribute and value (s).
+     * Create a {@linkplain Filter} on an attribute matching the given value(s).
      *
      * @param attribute the attribute to filter on
-     * @param values    the value(s) to filter on
+     * @param values    the value(s) to filter for
      * @return a new {@linkplain Filter}
      */
     public static Filter attributeIs( final SingularAttribute<?, ? extends Comparable<?>> attribute,
             final Comparable<?>... values ) {
-        final Attribute attr = Attribute.of( attribute );
-        final FilterBuilder builder = Filter.builder().attribute( attr );
-        for ( final Comparable<?> v : values ) {
-            builder.value( v );
-        }
-        return builder.build();
+        return attributeIs( Attribute.of( attribute ), values );
+    }
+
+    /**
+     * Create a {@linkplain Filter} on an attribute matching the given value(s).
+     *
+     * @param attribute the attribute to filter on
+     * @param values    the value(s) to filter for
+     * @return a new {@linkplain Filter}
+     */
+    public static Filter attributeIs( final SingularAttribute<?, ? extends Comparable<?>> attribute,
+            final Collection<Comparable<?>> values ) {
+        return attributeIs( Attribute.of( attribute ), values );
+    }
+
+    /**
+     * Create a {@linkplain Filter} on an attribute matching the given value(s).
+     *
+     * @param attribute the attribute to filter on
+     * @param values    the value(s) to filter for
+     * @return a new {@linkplain Filter}
+     */
+    public static Filter attributeIs( final Attribute attribute, final Comparable<?>... values ) {
+        return attributeIs( attribute, List.of( values ) );
+    }
+
+    /**
+     * Create a {@linkplain Filter} on an attribute matching the given value(s).
+     *
+     * @param attribute the attribute to filter on
+     * @param values    the value(s) to filter for
+     * @return a new {@linkplain Filter}
+     */
+    public static Filter attributeIs( final Attribute attribute, final Collection<Comparable<?>> values ) {
+        return Filter.create( b -> b.attribute( attribute ).values( values ) );
+    }
+
+    <T extends Comparable<? super T>> List<T> values( Class<T> valueType ) {
+        return values.stream()
+                .map( v -> valueType.isAssignableFrom( v.getClass() ) ? valueType.cast( v ) : null )
+                .toList();
     }
 
     /**

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Page.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Page.java
@@ -61,6 +61,15 @@ public class Page<E> implements Iterable<E> {
     }
 
     /**
+     * Check if the page is empty.
+     *
+     * @return {@code true} if the page is empty, {@code false} otherwise
+     */
+    public boolean isEmpty() {
+        return content.isEmpty();
+    }
+
+    /**
      * Loop over the content of the page
      *
      * @param action the action to perform on each element

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
@@ -111,7 +111,7 @@ public class PageRequest<E> {
         }
 
         /**
-         * Shortcut for adding a position spec of an attribute in ascending  order
+         * Shortcut for adding a position spec of an attribute in ascending order
          *
          * @param attribute the attribute used to create a position (ascending ordered)
          * @return the builder
@@ -121,13 +121,35 @@ public class PageRequest<E> {
         }
 
         /**
-         * Shortcut for adding a position spec of an attribute in descending  order
+         * Shortcut for adding a position spec of an attribute in descending order
          *
          * @param attribute the attribute used to create a position (descending ordered)
          * @return the builder
          */
         public PageRequestBuilder<E> desc( final Attribute attribute ) {
             return addPosition( Position.create( b -> b.attribute( attribute ).order( Order.DESC ) ) );
+        }
+
+        /**
+         * Shortcut for adding a position spec of an attribute in ascending order
+         *
+         * @param name the name of the attribute
+         * @param type the type of the attribute
+         * @return the builder
+         */
+        public PageRequestBuilder<E> asc( final String name, final Class<? extends Comparable<?>> type ) {
+            return addPosition( Position.create( b -> b.attribute( Attribute.of( name, type ) ).order( Order.ASC ) ) );
+        }
+
+        /**
+         * Shortcut for adding a position spec of an attribute in descending order
+         *
+         * @param name the name of the attribute
+         * @param type the type of the attribute
+         * @return the builder
+         */
+        public PageRequestBuilder<E> desc( final String name, final Class<? extends Comparable<?>> type ) {
+            return addPosition( Position.create( b -> b.attribute( Attribute.of( name, type ) ).order( Order.DESC ) ) );
         }
 
         /**

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Position.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Position.java
@@ -44,6 +44,31 @@ public class Position {
 
     private boolean reversed;
 
+    public static class PositionBuilder {
+
+        /**
+         * Builds a new position, verifies that at least one attribute has been provided
+         *
+         * @return a new position
+         */
+        public Position build() {
+            if ( attribute == null ) {
+                throw new IllegalStateException( "Attribute must not be null" );
+            } else if ( attribute.attributes().isEmpty() ) {
+                throw new IllegalStateException( "Attribute must not be empty" );
+            } else {
+                attribute.attributes().forEach( a -> {
+                    if ( a.name() == null || a.name().isBlank() ) {
+                        throw new IllegalStateException( "Attribute name must not be null or empty" );
+                    } else if ( a.type() == null ) {
+                        throw new IllegalStateException( "Attribute type must not be null" );
+                    }
+                } );
+            }
+            return new Position( attribute, value, order$value, reversed );
+        }
+    }
+
     /**
      * Creates a new {@link Position} with a builder.
      *

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
@@ -104,7 +104,7 @@ public class CriteriaQueryBuilder<E, R> implements QueryBuilder {
 
     private <V extends Comparable<? super V>> Predicate createGreaterThanOrEqualTo( final Attribute attribute,
             final V value ) {
-        return cb().greaterThanOrEqualTo( attribute.path( root ), value );
+        return cb.greaterThanOrEqualTo( attribute.path( root ), value );
     }
 
     @Override

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FilterTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FilterTest.java
@@ -1,0 +1,54 @@
+package io.vigier.cursorpaging.jpa;
+
+import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
+import io.vigier.cursorpaging.jpa.itest.model.DataRecord_;
+import jakarta.persistence.metamodel.SingularAttribute;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith( MockitoExtension.class )
+class FilterTest {
+
+    @Mock
+    private SingularAttribute<DataRecord, String> nameAttrMock;
+
+    @Test
+    void shouldCreateFilterFromJpaAttribute() {
+        final var value = "test";
+        Mockito.when( nameAttrMock.getName() ).thenReturn( "name" );
+        Mockito.when( nameAttrMock.getJavaType() ).thenReturn( String.class );
+        DataRecord_.name = nameAttrMock;
+        final var sut = Filter.attributeIs( DataRecord_.name, value );
+        verifyNameAndValue( sut, DataRecord_.NAME, value );
+    }
+
+    @Test
+    void shouldCreateFilterFromManualSpecifiedAttribute() {
+        final var value = "test";
+        final var sut = Filter.attributeIs( Attribute.of( DataRecord_.NAME, String.class ), value );
+        verifyNameAndValue( sut, DataRecord_.NAME, value );
+    }
+
+    @Test
+    void shouldCreateFilterFromManualSpecifiedAttributeWithMultipleValues() {
+        final String[] values = { "test", "test2" };
+        final var sut = Filter.attributeIs( Attribute.of( DataRecord_.NAME, String.class ), values );
+        verifyNameAndValue( sut, DataRecord_.NAME, values );
+    }
+
+
+    private static void verifyNameAndValue( final Filter sut, final String name, final String... values ) {
+        assertThat( sut ).isNotNull().satisfies( f -> {
+            assertThat( f.attribute() ).isNotNull().satisfies( a -> {
+                assertThat( a.name() ).isEqualTo( name );
+                assertThat( a.type() ).isEqualTo( String.class );
+            } );
+            assertThat( f.values( String.class ) ).containsExactly( values );
+        } );
+    }
+}

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
@@ -15,6 +15,7 @@ import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
 import io.vigier.cursorpaging.jpa.itest.model.DataRecord.Fields;
 import io.vigier.cursorpaging.jpa.itest.model.DataRecord_;
 import io.vigier.cursorpaging.jpa.itest.model.SecurityClass_;
+import io.vigier.cursorpaging.jpa.itest.model.Status;
 import io.vigier.cursorpaging.jpa.itest.repository.AccessEntryRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.DataRecordRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.SecurityClassRepository;
@@ -361,6 +362,25 @@ class PostgreSqlCursorPageTest {
 
         assertThat( page.size() ).isEqualTo( countPublicAccess );
         assertThat( count ).isEqualTo( countPublicAccess );
+    }
+
+    @Test
+    void shouldFilterByEnumAttribute() {
+        final List<DataRecord> all = testDataGenerator.generateData( 99 );
+        final int countDraft = (int) all.stream().filter( r -> r.getStatus() == Status.DRAFT ).count();
+        final int countActive = (int) all.stream().filter( r -> r.getStatus() == Status.ACTIVE ).count();
+
+        final var page = dataRecordRepository.loadPage( PageRequest.create( b -> b.pageSize( 99 )
+                .asc( DataRecord_.id )
+                .filter( Filter.attributeIs( DataRecord_.status, Status.DRAFT ) ) ) );
+
+        assertThat( page ).hasSize( countDraft );
+
+        final var page2 = dataRecordRepository.loadPage( PageRequest.create( b -> b.pageSize( 99 )
+                .asc( DataRecord_.id )
+                .filter( Filter.attributeIs( DataRecord_.status, Status.DRAFT, Status.ACTIVE ) ) ) );
+
+        assertThat( page2 ).hasSize( countDraft + countActive );
     }
 
     @RequiredArgsConstructor

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
@@ -3,6 +3,7 @@ package io.vigier.cursorpaging.jpa.itest;
 import io.vigier.cursorpaging.jpa.itest.model.AuditInfo;
 import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
 import io.vigier.cursorpaging.jpa.itest.model.SecurityClass;
+import io.vigier.cursorpaging.jpa.itest.model.Status;
 import io.vigier.cursorpaging.jpa.itest.repository.AccessEntryRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.DataRecordRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.SecurityClassRepository;
@@ -75,10 +76,15 @@ public class TestDataGenerator {
                     .name( nextName( i ) )
                     .securityClass( securityClasses[i % securityClasses.length] )
                     .auditInfo( AuditInfo.create( created, created.plus( 10, ChronoUnit.MINUTES ) ) )
+                    .status( nextStatus( i ) )
                     .build() ) );
         }
         log.info( "Generated {} test data-records", dataRecordRepository.count() );
         return allRecords;
+    }
+
+    private static Status nextStatus( final int i ) {
+        return Status.values()[i % Status.values().length];
     }
 
     private String nextName( final int i ) {

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/model/DataRecord.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/model/DataRecord.java
@@ -3,6 +3,8 @@ package io.vigier.cursorpaging.jpa.itest.model;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -49,6 +51,11 @@ public class DataRecord {
 
     @Builder.Default
     private AuditInfo auditInfo = new AuditInfo();
+
+    @Column( name = "status" )
+    @Enumerated( EnumType.STRING )
+    @Builder.Default
+    private Status status = Status.DRAFT;
 
     public static DataRecord create( final Consumer<DataRecordBuilder> c ) {
         final DataRecordBuilder b = DataRecord.builder();

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/model/Status.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/model/Status.java
@@ -1,0 +1,5 @@
+package io.vigier.cursorpaging.jpa.itest.model;
+
+public enum Status {
+    DRAFT, ACTIVE, INACTIVE, DELETED
+}


### PR DESCRIPTION
Fix:  `Path.as` creates a `cast()` for mapped enum attributes

Improvement: Some additional convenient functions in API