### PR TITLE
Major refactoring to support or/and operations in filters.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.kordamp.gradle:project-gradle-plugin:$kordampVersion")
     implementation("org.kordamp.gradle:spotbugs-gradle-plugin:$kordampVersion")
     implementation("org.kordamp.gradle:coveralls-gradle-plugin:$kordampVersion")
+    implementation("org.sonarqube:org.sonarqube.gradle.plugin:5.1.0.4882")
 //    implementation("org.kordamp.gradle:base-gradle-plugin:$kordampVersion")
 //    implementation("org.kordamp.gradle:jacoco-gradle-plugin:$kordampVersion")
     implementation("gradle.plugin.org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.12.2")

--- a/buildSrc/src/main/kotlin/io.vigier.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.vigier.java-library-conventions.gradle.kts
@@ -39,6 +39,10 @@ tasks.named<Jar>("bootJar") {
 tasks {
     jacocoTestReport {
         dependsOn(tasks.test) // tests are required to run before generating the report
+        reports {
+            xml.required = true
+            html.required = true
+        }
     }
     delombok {
         enabled = false
@@ -47,6 +51,7 @@ tasks {
         archiveClassifier.set("") // needed to remove "-plain" when bootJar = false
     }
     test {
+        finalizedBy(tasks.jacocoTestReport)
         testLogging {
             events(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.STANDARD_OUT)
             showExceptions = true

--- a/buildSrc/src/main/kotlin/io.vigier.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.vigier.java-library-conventions.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 // File: buildSrc/src/main/kotlin/java-project-conventions.gradle.kts
 plugins {
     id("java-library")
@@ -9,6 +12,7 @@ plugins {
     id("org.kordamp.gradle.spotbugs")
     id("com.github.kt3k.coveralls")
     id("org.kordamp.gradle.coveralls")
+    id("org.sonarqube")
 }
 
 group = "io.vigier.cursorpaging"
@@ -42,7 +46,17 @@ tasks {
     jar {
         archiveClassifier.set("") // needed to remove "-plain" when bootJar = false
     }
+    test {
+        testLogging {
+            events(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.STANDARD_OUT)
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+            exceptionFormat = TestExceptionFormat.FULL
+        }
+    }
 }
+
 config {
     info {
         inceptionYear = "2024"

--- a/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
+++ b/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
@@ -123,22 +123,17 @@ public class DataRecordController {
                     mediaType = MediaType.APPLICATION_JSON_VALUE, //
                     schema = @Schema( implementation = DtoPageRequest.class, example = """
                             {
-                                "orderBy": {
-                                    "id": "ASC"
-                                },
+                                "orderBy": { "id": "ASC" },
                                 "filterBy": {
                                     "AND": [
-                                        {
-                                            "GT": { "beast": ["666"] }
-                                        },
-                                        {
-                                            "EQ": { "color": ["black"] }
-                                        }
+                                        { "EQ": { "name": [ "Bravo" ] } },
+                                        { "GT": { "created_at": [ "1999-01-30T10:15:30Z" ] } }
                                     ]
                                 },
                                 "pageSize": 10,
                                 "withTotalCount": false
-                             }""" ) ) ) //
+                            }
+                            """ ) ) ) //
             @RequestBody final DtoPageRequest request ) {
         request.addOrderByIfAbsent( DataRecord_.ID, Order.ASC );
         final PageRequest<DataRecord> pageRequest = request.toPageRequest( DataRecordAttribute::forName );

--- a/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
+++ b/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
@@ -123,15 +123,21 @@ public class DataRecordController {
                     mediaType = MediaType.APPLICATION_JSON_VALUE, //
                     schema = @Schema( implementation = DtoPageRequest.class, example = """
                             {
-                               "orderBy": {
-                                 "NAME": "ASC"
-                               },
-                               "filterBy": {
-                                 "NAME": [
-                                   "Bravo", "Tango"
-                                 ]
-                               },
-                               "pageSize": 100
+                                "orderBy": {
+                                    "id": "ASC"
+                                },
+                                "filterBy": {
+                                    "AND": [
+                                        {
+                                            "GT": { "beast": ["666"] }
+                                        },
+                                        {
+                                            "EQ": { "color": ["black"] }
+                                        }
+                                    ]
+                                },
+                                "pageSize": 10,
+                                "withTotalCount": false
                              }""" ) ) ) //
             @RequestBody final DtoPageRequest request ) {
         request.addOrderByIfAbsent( DataRecord_.ID, Order.ASC );

--- a/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
+++ b/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordController.java
@@ -16,7 +16,7 @@ import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.api.DtoPageRequest;
 import io.vigier.cursorpaging.jpa.serializer.Base64String;
-import io.vigier.cursorpaging.jpa.serializer.EntitySerializer;
+import io.vigier.cursorpaging.jpa.serializer.RequestSerializer;
 import io.vigier.cursorpaging.jpa.validation.MaxSize;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +55,7 @@ public class DataRecordController {
     // Skipping the service layer ;-)
     private final DataRecordRepository dataRecordRepository;
     private final DtoDataRecordMapper dtoDataRecordMapper;
-    private final EntitySerializer<DataRecord> serializer;
+    private final RequestSerializer<DataRecord> serializer;
 
     @Operation( summary = "Get data records, page by page" )
     @GetMapping( produces = MediaType.APPLICATION_JSON_VALUE )

--- a/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/model/DataRecordAttribute.java
+++ b/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/api/model/DataRecordAttribute.java
@@ -15,7 +15,7 @@ public enum DataRecordAttribute {
     // Not using the "lowercase" properties here, because there are tests where no EntityManager is instantiated
     // (i.e. the MockMVC test), but this one is needed to populate them :-(
 
-    ID( Attribute.of( DataRecord_.NAME, UUID.class ) ),
+    ID( Attribute.of( DataRecord_.ID, UUID.class ) ),
     NAME( Attribute.of( DataRecord_.NAME, String.class ) ),
     CREATED_AT( Attribute.path( DataRecord_.AUDIT_INFO, AuditInfo.class, AuditInfo_.CREATED_AT, Instant.class ) ),
     MODIFIED_AT( Attribute.path( DataRecord_.AUDIT_INFO, AuditInfo.class, AuditInfo_.MODIFIED_AT, Instant.class ) );

--- a/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/config/RequestSerializerConfig.java
+++ b/cursorpaging-examples/webapp-with-maven/src/main/java/io/vigier/cursorpaging/example/webapp/config/RequestSerializerConfig.java
@@ -2,29 +2,30 @@ package io.vigier.cursorpaging.example.webapp.config;
 
 import io.vigier.cursorpaging.example.webapp.model.DataRecord;
 import io.vigier.cursorpaging.jpa.serializer.Encrypter;
-import io.vigier.cursorpaging.jpa.serializer.EntitySerializer;
-import io.vigier.cursorpaging.jpa.serializer.EntitySerializerFactory;
+import io.vigier.cursorpaging.jpa.serializer.RequestSerializer;
+import io.vigier.cursorpaging.jpa.serializer.RequestSerializerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.ConversionService;
 
 @Configuration
-public class EntitySerializerConfig {
+public class RequestSerializerConfig {
 
     @Value( "${cursorpaging.jpa.serializer.encrypter.secret:1234567890ABCDEFGHIJKlmnopqrst--}" )
     private String encrypterSecret;
 
     @Bean
-    public EntitySerializerFactory entitySerializerFactory( final ConversionService conversionService ) {
-        return EntitySerializerFactory.builder()
+    public RequestSerializerFactory requestSerializerFactory( final ConversionService conversionService ) {
+        return RequestSerializerFactory.builder()
                 .conversionService( conversionService )
                 .encrypter( Encrypter.getInstance( encrypterSecret ) )
                 .build();
     }
 
     @Bean
-    public EntitySerializer<DataRecord> dataRecordEntitySerializer( final EntitySerializerFactory serializerFactory ) {
+    public RequestSerializer<DataRecord> dataRecordRequestSerializer(
+            final RequestSerializerFactory serializerFactory ) {
         return serializerFactory.forEntity( DataRecord.class );
     }
 }

--- a/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
+++ b/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" title="Spring-CursorPaging WebApp">
+<title>Spring-CursorPaging Example WebApp</title>
 <body>
-<h2>Cursor Paging Test App</h2>
-<p>API</p>
-<a href="swagger-ui/index.html">swagger-ui</a>
+<h1><i>Spring-CursorPaging</i> Example API</h1>
+<a style="border: blue 1px solid" href="swagger-ui/index.html">swagger-ui</a>
 </body>
 </html>

--- a/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
+++ b/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
@@ -1,4 +1,5 @@
-<html lang="en">
+<!DOCTYPE html>
+<html lang="en" title="Spring-CursorPaging WebApp">
 <body>
 <h2>Cursor Paging Test App</h2>
 <p>API</p>

--- a/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
+++ b/cursorpaging-examples/webapp-with-maven/src/main/resources/static/index.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html lang="en" title="Spring-CursorPaging WebApp">
-<title>Spring-CursorPaging Example WebApp</title>
+<head>
+  <title>Spring-CursorPaging Example WebApp</title>
+</head>
 <body>
 <h1><i>Spring-CursorPaging</i> Example API</h1>
-<a style="border: blue 1px solid" href="swagger-ui/index.html">swagger-ui</a>
+<a href="swagger-ui/index.html" style="border: blue 1px solid">swagger-ui</a>
 </body>
 </html>

--- a/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/ExampleWebApplicationTests.java
+++ b/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/ExampleWebApplicationTests.java
@@ -60,7 +60,7 @@ class ExampleWebApplicationTests {
 	}
 	@Test
 	void contextLoads() {
-
+		// Fails when Spring's ApplicationContext cannot be created
 	}
 
 	@Test

--- a/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordControllerTest.java
+++ b/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordControllerTest.java
@@ -10,7 +10,7 @@ import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.api.DtoPageRequest;
 import io.vigier.cursorpaging.jpa.serializer.Base64String;
-import io.vigier.cursorpaging.jpa.serializer.EntitySerializer;
+import io.vigier.cursorpaging.jpa.serializer.RequestSerializer;
 import java.util.Base64;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -48,7 +48,7 @@ class DataRecordControllerTest {
     private DtoDataRecordMapper dtoDataRecordMapper;
 
     @MockBean
-    private EntitySerializer<DataRecord> serializer;
+    private RequestSerializer<DataRecord> serializer;
 
     @Test
     void shouldValidateMaxPageSize() throws Exception {

--- a/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordControllerTest.java
+++ b/cursorpaging-examples/webapp-with-maven/src/test/java/io/vigier/cursorpaging/example/webapp/api/controller/DataRecordControllerTest.java
@@ -9,9 +9,13 @@ import io.vigier.cursorpaging.jpa.Attribute;
 import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.api.DtoPageRequest;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoAndFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoEqFilter;
 import io.vigier.cursorpaging.jpa.serializer.Base64String;
 import io.vigier.cursorpaging.jpa.serializer.RequestSerializer;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.hamcrest.Matchers;
@@ -89,9 +93,16 @@ class DataRecordControllerTest {
 
     @Test
     void shouldCreateNewCursorOnPost() throws Exception {
-        final var request = new DtoPageRequest().withFilterBy( DataRecord_.NAME, "Tango", "Bravo" )
-                .withOrderBy( DataRecord_.NAME, Order.ASC )
-                .withPageSize( 10 );
+        final var request = DtoPageRequest.builder()
+                .filterBy( DtoAndFilter.builder()
+                        .filter( DtoEqFilter.builder()
+                                .attribute( DataRecord_.NAME )
+                                .values( List.of( "Tango", "Bravo" ) )
+                                .build() )
+                        .build() )
+                .orderBy( Map.of( DataRecord_.NAME, Order.ASC ) )
+                .pageSize( 10 )
+                .build();
         final String json = new ObjectMapper().writeValueAsString( request );
         log.debug( "Json:, {}", json );
 
@@ -103,9 +114,10 @@ class DataRecordControllerTest {
                 .andExpect( status().isCreated() ) //
                 .andExpect( jsonPath( "$.orderBy.name" ).value( "ASC" ) )
                 .andExpect( jsonPath( "$.orderBy.id" ).value( "ASC" ) )
-                .andExpect( jsonPath( "$.filterBy.name" ).isArray() )
-                .andExpect( jsonPath( "$.filterBy.name[0]" ).value( "Tango" ) )
-                .andExpect( jsonPath( "$.filterBy.name[1]" ).value( "Bravo" ) )
+                .andExpect( jsonPath( "$.filterBy.AND" ).isArray() )
+                .andExpect( jsonPath( "$.filterBy.AND[0].EQ.name" ).isArray() )
+                .andExpect( jsonPath( "$.filterBy.AND[0].EQ.name[0]" ).value( "Tango" ) )
+                .andExpect( jsonPath( "$.filterBy.AND[0].EQ.name[1]" ).value( "Bravo" ) )
                 .andExpect( jsonPath( "$.pageSize" ).value( 10 ) ) //
                 .andExpect( jsonPath( "$._links.first.href" ).exists() )
                 .andExpect( jsonPath( "$._links.first.href" ).value( Matchers.containsString( CURSOR ) ) );

--- a/cursorpaging-jpa-api/build.gradle.kts
+++ b/cursorpaging-jpa-api/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 	implementation("com.google.protobuf:protobuf-java:4.28.2")
 	api("org.springframework:spring-core")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
+	implementation("com.fasterxml.jackson.core:jackson-databind")
 	api("jakarta.validation:jakarta.validation-api")
 	api("jakarta.persistence:jakarta.persistence-api:3.2.0")
 

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
@@ -23,6 +23,7 @@ import io.vigier.cursorpaging.jpa.Filters;
 import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.QueryElement;
+import io.vigier.cursorpaging.jpa.filter.FilterList;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.io.IOException;
@@ -265,7 +266,7 @@ public class DtoPageRequest {
                 }
             } );
             b.pageSize( pageSize ).enableTotalCount( withTotalCount );
-            filterBy.forEach( f -> b.filter( filterOf( f, attributeProvider ) ) );
+            b.filters( (FilterList) filterOf( filterBy, attributeProvider ) );
         } );
     }
 

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -148,7 +147,7 @@ public class DtoPageRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     @SuperBuilder
-    public static abstract class DtoFilterList implements DtoFilterElement, Iterable<DtoFilterElement> {
+    public abstract static class DtoFilterList implements DtoFilterElement, Iterable<DtoFilterElement> {
 
         @Singular
         private List<DtoFilterElement> filters;
@@ -175,19 +174,13 @@ public class DtoPageRequest {
 
     public abstract static class DtoFilterListDeserializer extends StdDeserializer<DtoFilterList> {
 
-        public DtoFilterListDeserializer() {
-            this( null );
-        }
-
-        public DtoFilterListDeserializer( Class<? extends DtoFilterList> vc ) {
+        protected DtoFilterListDeserializer( Class<? extends DtoFilterList> vc ) {
             super( vc );
         }
 
         @Override
-        public DtoFilterList deserialize( JsonParser jp, DeserializationContext ctxt )
-                throws IOException, JsonProcessingException {
+        public DtoFilterList deserialize( JsonParser jp, DeserializationContext ctxt ) throws IOException {
             JsonNode node = jp.getCodec().readTree( jp );
-            final var first = node.get( 0 );
             List<DtoFilterElement> filterList = new LinkedList<>();
             for ( JsonNode n : node ) {
                 filterList.add( jp.getCodec().treeToValue( n, DtoFilterElement.class ) );

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/api/DtoPageRequest.java
@@ -1,46 +1,265 @@
 package io.vigier.cursorpaging.jpa.api;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.vigier.cursorpaging.jpa.Attribute;
 import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.Filters;
 import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
+import io.vigier.cursorpaging.jpa.QueryElement;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.util.LinkedHashMap;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+import lombok.experimental.SuperBuilder;
 
 /**
  * {@link PageRequest} representation, which can be used in a REST API as request body.
  */
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude( Include.NON_NULL )
 public class DtoPageRequest {
 
-    private final Map<String, Order> orderBy = new LinkedHashMap<>();
+    private Map<String, Order> orderBy;
 
-    private final Map<String, List<String>> filterBy = new LinkedHashMap<>();
+    @JsonTypeInfo( use = Id.NAME, include = As.WRAPPER_OBJECT )
+    @JsonSubTypes( { @Type( value = DtoAndFilter.class, name = "AND" ), @Type( value = DtoOrFilter.class, name = "OR" ),
+            @Type( value = DtoEqFilter.class, name = "EQ" ), @Type( value = DtoGtFilter.class, name = "GT" ),
+            @Type( value = DtoLtFilter.class, name = "LT" ), @Type( value = DtoLikeFilter.class, name = "LIKE" ) } )
+    public interface DtoFilterElement {
+
+    }
+
+    @Builder.Default
+    private final DtoFilterList filterBy = new DtoAndFilter();
+
+    @Data
+    @NoArgsConstructor
+    @SuperBuilder
+    public abstract static class DtoFilter implements DtoFilterElement {
+
+        @JsonIgnore
+        private String attribute;
+        @JsonIgnore
+        @Singular
+        private List<String> values;
+
+        public abstract Filter create( Attribute attribute, List<? extends Comparable<?>> values );
+
+        @JsonAnyGetter
+        public Map<String, List<String>> getJson() {
+            return Map.of( attribute, values );
+        }
+
+        @JsonAnySetter
+        public void setAttribute( String name, Object value ) {
+            this.attribute = name;
+            this.values = value instanceof List<?> l ? l.stream().map( Objects::toString ).toList() : List.of();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "EQ" )
+    public static class DtoEqFilter extends DtoFilter {
+
+        @Override
+        public Filter create( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+            return Filters.attribute( attribute ).equalTo( values );
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "GT" )
+    public static class DtoGtFilter extends DtoFilter {
+
+        @Override
+        public Filter create( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+            return Filters.attribute( attribute ).greaterThan( values );
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "LT" )
+    public static class DtoLtFilter extends DtoFilter {
+
+        @Override
+        public Filter create( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+            return Filters.attribute( attribute ).lessThan( values );
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "LIKE" )
+    public static class DtoLikeFilter extends DtoFilter {
+
+        @Override
+        public Filter create( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+            return Filters.attribute( attribute ).like( values );
+        }
+
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @SuperBuilder
+    public static abstract class DtoFilterList implements DtoFilterElement, Iterable<DtoFilterElement> {
+
+        @Singular
+        private List<DtoFilterElement> filters;
+
+        @JsonValue
+        public List<DtoFilterElement> getFilters() {
+            return filters;
+        }
+
+        @Override
+        public Iterator<DtoFilterElement> iterator() {
+            return filters.iterator();
+        }
+
+        @Override
+        public void forEach( final Consumer<? super DtoFilterElement> action ) {
+            filters.forEach( action );
+        }
+
+        public int size() {
+            return filters.size();
+        }
+    }
+
+    public abstract static class DtoFilterListDeserializer extends StdDeserializer<DtoFilterList> {
+
+        public DtoFilterListDeserializer() {
+            this( null );
+        }
+
+        public DtoFilterListDeserializer( Class<? extends DtoFilterList> vc ) {
+            super( vc );
+        }
+
+        @Override
+        public DtoFilterList deserialize( JsonParser jp, DeserializationContext ctxt )
+                throws IOException, JsonProcessingException {
+            JsonNode node = jp.getCodec().readTree( jp );
+            final var first = node.get( 0 );
+            List<DtoFilterElement> filterList = new LinkedList<>();
+            for ( JsonNode n : node ) {
+                filterList.add( jp.getCodec().treeToValue( n, DtoFilterElement.class ) );
+            }
+            return create( filterList );
+        }
+
+        protected abstract DtoFilterList create( List<DtoFilterElement> filters );
+    }
+
+    public static class DtoAndFilterListDeserializer extends DtoFilterListDeserializer {
+
+        public DtoAndFilterListDeserializer() {
+            super( DtoAndFilter.class );
+        }
+
+        @Override
+        protected DtoFilterList create( List<DtoFilterElement> filters ) {
+            return DtoAndFilter.builder().filters( filters )
+                    .build();
+        }
+    }
+
+    public static class DtoOrFilterListDeserializer extends DtoFilterListDeserializer {
+
+        public DtoOrFilterListDeserializer() {
+            super( DtoOrFilter.class );
+        }
+
+        @Override
+        protected DtoFilterList create( List<DtoFilterElement> filters ) {
+            return DtoOrFilter.builder().filters( filters )
+                    .build();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "AND" )
+    @JsonDeserialize( using = DtoAndFilterListDeserializer.class )
+    public static class DtoAndFilter extends DtoFilterList {
+
+        @JsonAnySetter
+        public void setContent( Map<String, List<DtoFilterElement>> filters ) {
+            setFilters( filters.entrySet().iterator().next().getValue() );
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @EqualsAndHashCode( callSuper = true )
+    @SuperBuilder
+    @JsonTypeName( "OR" )
+    @JsonDeserialize( using = DtoOrFilterListDeserializer.class )
+    public static class DtoOrFilter extends DtoFilterList {
+
+    }
+
 
     @Min( 1 )
     @Max( 100 )
+    @Builder.Default
     private int pageSize = 100; // Must not be final!
 
     private boolean withTotalCount;
 
-    public DtoPageRequest withPageSize( final int pageSize ) {
-        this.pageSize = pageSize;
-        return this;
-    }
-
-    public DtoPageRequest withOrderBy( final String name, final Order order ) {
-        orderBy.put( name, order );
-        return this;
-    }
-
-    public DtoPageRequest withFilterBy( final String name, final String... values ) {
-        filterBy.put( name, List.of( values ) );
-        return this;
+    public static DtoPageRequest create( Consumer<DtoPageRequestBuilder> c ) {
+        final DtoPageRequestBuilder builder = DtoPageRequest.builder();
+        c.accept( builder );
+        return builder.build();
     }
 
     public <T> PageRequest<T> toPageRequest( final Function<String, Attribute> attributeProvider ) {
@@ -52,12 +271,21 @@ public class DtoPageRequest {
                     case DESC -> b.desc( attribute );
                 }
             } );
-            filterBy.forEach( ( name, values ) -> {
-                final Attribute attribute = attributeProvider.apply( name );
-                b.filter( Filter.create( fb -> fb.attribute( attribute ).values( values ) ) );
-            } );
             b.pageSize( pageSize ).enableTotalCount( withTotalCount );
+            filterBy.forEach( f -> b.filter( filterOf( f, attributeProvider ) ) );
         } );
+    }
+
+    private QueryElement filterOf( final DtoFilterElement f, final Function<String, Attribute> attributeProvider ) {
+        if ( f instanceof DtoFilter filter ) {
+            final Attribute attribute = attributeProvider.apply( filter.getAttribute() );
+            return filter.create( attribute, filter.getValues() );
+        } else if ( f instanceof DtoAndFilter list ) {
+            return Filters.and( list.getFilters().stream().map( e -> filterOf( e, attributeProvider ) ).toList() );
+        } else if ( f instanceof DtoOrFilter list ) {
+            return Filters.or( list.getFilters().stream().map( e -> filterOf( e, attributeProvider ) ).toList() );
+        }
+        throw new IllegalStateException( "Unknown filter element: " + (f != null ? f.getClass().getName() : "null") );
     }
 
     public void addOrderByIfAbsent( final String name, final Order order ) {

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/Base64String.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/Base64String.java
@@ -11,14 +11,14 @@ import java.util.stream.IntStream;
  */
 public class Base64String implements CharSequence {
 
-    private final String base64String;
+    private final String encoded;
 
     public Base64String( final String base64String ) {
-        this.base64String = validate( base64String );
+        this.encoded = validate( base64String );
     }
 
     public Base64String( final byte[] bytes ) {
-        this.base64String = new String( bytes, StandardCharsets.UTF_8 );
+        this.encoded = new String( bytes, StandardCharsets.UTF_8 );
     }
 
     public static Base64String encode( final byte[] content ) {
@@ -42,7 +42,7 @@ public class Base64String implements CharSequence {
      * @return the decoded byte array of the base64 string
      */
     public byte[] decoded() {
-        return decode( base64String );
+        return decode( encoded );
     }
 
     private static byte[] decode( final String base64String ) {
@@ -51,37 +51,37 @@ public class Base64String implements CharSequence {
 
     @Override
     public int length() {
-        return base64String.length();
+        return encoded.length();
     }
 
     @Override
     public char charAt( final int index ) {
-        return base64String.charAt( index );
+        return encoded.charAt( index );
     }
 
     @Override
     public boolean isEmpty() {
-        return base64String.isEmpty();
+        return encoded.isEmpty();
     }
 
     @Override
     public @NotNull CharSequence subSequence( final int start, final int end ) {
-        return base64String.subSequence( start, end );
+        return encoded.subSequence( start, end );
     }
 
     @Override
     public @NotNull IntStream chars() {
-        return base64String.chars();
+        return encoded.chars();
     }
 
     @Override
     public @NotNull IntStream codePoints() {
-        return base64String.codePoints();
+        return encoded.codePoints();
     }
 
     @Override
     public @NotNull String toString() {
-        return base64String;
+        return encoded;
     }
 
     /**
@@ -92,6 +92,6 @@ public class Base64String implements CharSequence {
      * @return a new Base64String with the replaced sequence
      */
     public Base64String replace( final String target, final String replacement ) {
-        return new Base64String( base64String.replace( target, replacement ) );
+        return new Base64String( encoded.replace( target, replacement ) );
     }
 }

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/Encrypter.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/Encrypter.java
@@ -22,10 +22,10 @@ import lombok.SneakyThrows;
 @RequiredArgsConstructor
 public class Encrypter {
 
-    public final static String KEY_ALGORITHM = "ChaCha20";
-    public final static int IV_BYTES_LENGTH = 12;
+    public static final String KEY_ALGORITHM = "ChaCha20";
+    public static final int IV_BYTES_LENGTH = 12;
 
-    private final static String ALGORITHM = "ChaCha20-Poly1305";
+    private static final String ALGORITHM = "ChaCha20-Poly1305";
 
     /**
      * The random generator to use for generating the initial vector (IV). Potentially this can be replaced by a

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
@@ -2,27 +2,47 @@ package io.vigier.cursorpaging.jpa.serializer;
 
 import io.vigier.cursorpaging.jpa.Attribute;
 import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.FilterRule;
 import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.Position;
+import io.vigier.cursorpaging.jpa.QueryElement;
+import io.vigier.cursorpaging.jpa.filter.AndFilter;
+import io.vigier.cursorpaging.jpa.filter.FilterBuilder.FilterType;
+import io.vigier.cursorpaging.jpa.filter.FilterList;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
 import io.vigier.cursorpaging.jpa.serializer.dto.Cursor;
+import io.vigier.cursorpaging.jpa.serializer.dto.Cursor.Value;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionService;
 
+@Slf4j
 @Builder
 @RequiredArgsConstructor( staticName = "of" )
 class FromDtoMapper<E> {
+
+    private static final Map<Cursor.FilterType, FilterType> FILTER_TYPE_MAP = Map.of( //
+            Cursor.FilterType.EQ, FilterType.EQUAL, //
+            Cursor.FilterType.GT, FilterType.GREATER_THAN, //
+            Cursor.FilterType.LT, FilterType.LESS_THAN, //
+            Cursor.FilterType.LIKE, FilterType.LIKE, //
+            Cursor.FilterType.UNRECOGNIZED, FilterType.EQUAL //
+    );
 
     private final Cursor.PageRequest request;
     @Builder.Default
     private final Map<String, Attribute> attributesByName = new HashMap<>();
     private final ConversionService conversionService;
+    private final Map<String, RuleFactory> ruleFactories;
 
     public  static <T> FromDtoMapper<T> create( final Consumer<FromDtoMapperBuilder<T>> c ) {
         final var builder = FromDtoMapper.<T>builder();
@@ -31,29 +51,70 @@ class FromDtoMapper<E> {
     }
 
     public PageRequest<E> map() {
-        return PageRequest.<E>builder().positions( positions() ).filters( filters() ).pageSize( request.getPageSize() )
+        return PageRequest.<E>builder()
+                .positions( positions() )
+                .filters( filters() ) //
+                .pageSize( request.getPageSize() )
                 .enableTotalCount( request.hasTotalCount() )
-                .totalCount( request.hasTotalCount() ? request.getTotalCount() : null )
+                .totalCount( request.hasTotalCount() ? request.getTotalCount() : null ) //
+                .rules( filterRules() )
                 .build();
+    }
+
+    private List<FilterRule> filterRules() {
+        return request.getFilterRulesList().stream().map( this::filterRuleOf ).filter( Objects::nonNull ).toList();
+    }
+
+    private FilterRule filterRuleOf( Cursor.Rule rule ) {
+        final var factory = ruleFactories.get( rule.getName() );
+        if ( factory != null ) {
+            Map<String, List<String>> parameters = new HashMap<>();
+            rule.getParametersList()
+                    .forEach( p -> parameters.put( p.getName(),
+                            p.getValuesList().stream().map( Value::getValue ).toList() ) );
+            return factory.apply( parameters );
+        }
+        return null;
     }
 
     private Collection<Position> positions() {
         return request.getPositionsList().stream().map( this::positionOf ).toList();
     }
 
-    private Collection<Filter> filters() {
-        return request.getFiltersList().stream().map( this::filterOf ).toList();
+    private FilterList filters() {
+        return fromFilterListDto( request.getFilters() );
     }
 
-    private Filter filterOf( final Cursor.Filter filter ) {
-        final var attribute = attributeOf( filter.getAttribute() );
-        return Filter.create(
-                b -> b.attribute( attribute ).values( valueListOf( attribute, filter.getValuesList() ) ) );
+    private FilterList fromFilterListDto( final Cursor.FilterList dto ) {
+        List<QueryElement> filters = new LinkedList<>();
+        
+        filters.addAll( dto.getFiltersList().stream().map( this::fromFilterDto ).toList() );
+        filters.addAll( dto.getFilterListsList().stream().map( this::fromFilterListDto ).toList() );
+        return switch ( dto.getType() ) {
+            case AND, UNRECOGNIZED -> AndFilter.of( filters );
+            case OR -> OrFilter.of( filters );
+        };
     }
 
-    private <T extends Comparable<? super T>> List<T> valueListOf( final Attribute attribute,
+    private Filter fromFilterDto( Cursor.Filter dto ) {
+        final var attribute = attributeOf( dto.getAttribute() );
+        final var values = valueListOf( attribute, dto.getValuesList() );
+        return Filter.builder().attribute( attribute ).values( values ).type( getFilterType( dto ) )
+                .build();
+    }
+
+    private FilterType getFilterType( final Cursor.Filter dto ) {
+        return FILTER_TYPE_MAP.get( dto.getType() );
+    }
+
+    private List<? extends Comparable<?>> valueListOf( final Attribute attribute,
             final List<Cursor.Value> valuesList ) {
-        return valuesList.stream().map( v -> this.<T>valueOf( attribute, v ) ).toList();
+        return valuesList.stream().map( v -> {
+            Comparable<?> converted = valueOf( attribute, v );
+            log.trace( "Converted: {} into {} (value={})", v.getClass().getSimpleName(),
+                    (converted != null ? converted.getClass().getSimpleName() : null), converted );
+            return converted;
+        } ).toList();
     }
 
     private <T extends Comparable<? super T>> T valueOf( final Attribute attribute, final Cursor.Value value ) {

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactory.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactory.java
@@ -8,7 +8,7 @@ import org.springframework.core.convert.ConversionService;
 
 @Builder
 @RequiredArgsConstructor
-public class EntitySerializerFactory {
+public class RequestSerializerFactory {
 
     private final ConversionService conversionService;
 
@@ -16,11 +16,11 @@ public class EntitySerializerFactory {
     private final Encrypter encrypter = Encrypter.getInstance();
 
     @Builder.Default
-    private final Map<Class<?>, EntitySerializer<?>> entitySerializers = new ConcurrentHashMap<>();
+    private final Map<Class<?>, RequestSerializer<?>> entitySerializers = new ConcurrentHashMap<>();
 
     @SuppressWarnings( "unchecked" )
-    public <T> EntitySerializer<T> forEntity( final Class<T> entityClass ) {
-        return (EntitySerializer<T>) entitySerializers.computeIfAbsent( entityClass,
-                k -> EntitySerializer.create( b -> b.encrypter( encrypter ).conversionService( conversionService ) ) );
+    public <T> RequestSerializer<T> forEntity( final Class<T> entityClass ) {
+        return (RequestSerializer<T>) entitySerializers.computeIfAbsent( entityClass,
+                k -> RequestSerializer.create( b -> b.encrypter( encrypter ).conversionService( conversionService ) ) );
     }
 }

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RuleFactory.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RuleFactory.java
@@ -1,0 +1,10 @@
+package io.vigier.cursorpaging.jpa.serializer;
+
+import io.vigier.cursorpaging.jpa.FilterRule;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public interface RuleFactory extends Function<Map<String, List<String>>, FilterRule> {
+
+}

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
@@ -1,31 +1,105 @@
 package io.vigier.cursorpaging.jpa.serializer;
 
 import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.FilterRule;
 import io.vigier.cursorpaging.jpa.PageRequest;
+import io.vigier.cursorpaging.jpa.filter.AndFilter;
+import io.vigier.cursorpaging.jpa.filter.EqualFilter;
+import io.vigier.cursorpaging.jpa.filter.FilterList;
+import io.vigier.cursorpaging.jpa.filter.GreaterThanFilter;
+import io.vigier.cursorpaging.jpa.filter.LessThanFilter;
+import io.vigier.cursorpaging.jpa.filter.LikeFilter;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
 import io.vigier.cursorpaging.jpa.serializer.dto.Cursor;
+import io.vigier.cursorpaging.jpa.serializer.dto.Cursor.FilterList.FilterListType;
+import io.vigier.cursorpaging.jpa.serializer.dto.Cursor.FilterType;
+import io.vigier.cursorpaging.jpa.serializer.dto.Cursor.Rule.Parameter;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 
+@Builder
 @RequiredArgsConstructor( staticName = "of" )
 class ToDtoMapper<E> {
 
+    private static final Map<Class<? extends Filter>, FilterType> TYPE_MAP = Map.of( //
+            EqualFilter.class, FilterType.EQ, //
+            GreaterThanFilter.class, FilterType.GT, //
+            LessThanFilter.class, FilterType.LT, //
+            LikeFilter.class, FilterType.LIKE //
+    );
+    private static final Map<Class<? extends FilterList>, FilterListType> LISTTYPE_MAP = Map.of( //
+            AndFilter.class, FilterListType.AND, //
+            OrFilter.class, FilterListType.OR );
+
     private final PageRequest<E> pageRequest;
+
+    public static <E> ToDtoMapper<E> create( final Consumer<ToDtoMapperBuilder<E>> c ) {
+        final var builder = ToDtoMapper.<E>builder();
+        c.accept( builder );
+        return builder.build();
+    }
 
     public Cursor.PageRequest map() {
         final var builder = Cursor.PageRequest.newBuilder()
                 .addAllPositions( positions() )
                 .setPageSize( pageRequest.pageSize() )
-                .addAllFilters( filters() );
+                .setFilters( filters() )
+                .addAllFilterRules( filterRules() );
         pageRequest.totalCount().ifPresent( builder::setTotalCount );
         return builder.build();
     }
 
+    private Iterable<Cursor.Rule> filterRules() {
+        return pageRequest.rules()
+                .stream()
+                .map( r -> Cursor.Rule.newBuilder().setName( r.name() ).addAllParameters( toDtoParameters( r ) )
+                        .build() )
+                .toList();
+    }
 
-    private Iterable<Cursor.Filter> filters() {
-        return pageRequest.filters().stream()
-                .map( f -> Cursor.Filter.newBuilder().setAttribute( attributeOf( f.attribute() ) )
-                        .addAllValues( f.values().stream().map( this::valueOf ).toList() )
-                        .build() ).toList();
+    private List<Parameter> toDtoParameters( final FilterRule r ) {
+        return r.parameters()
+                .entrySet()
+                .stream()
+                .map( e -> Parameter.newBuilder()
+                        .setName( e.getKey() )
+                        .addAllValues( e.getValue().stream().map( this::valueOf ).toList() )
+                        .build() )
+                .toList();
+    }
+
+
+    private Cursor.FilterList filters() {
+        return toDto( pageRequest.filters() );
+    }
+
+    private Cursor.FilterList toDto( FilterList list ) {
+        Cursor.FilterList.Builder b = Cursor.FilterList.newBuilder().setType( typeOf( list ) );
+        list.forEach( f -> {
+            if ( f instanceof Filter ff ) {
+                b.addFilters( Cursor.Filter.newBuilder()
+                        .setAttribute( attributeOf( ff.attribute() ) )
+                        .addAllValues( ff.values().stream().map( this::valueOf ).toList() )
+                        .setType( typeOf( ff ) )
+                        .build() );
+            } else if ( f instanceof FilterList fl ) {
+                b.addFilterLists( toDto( fl ) );
+            }
+        } );
+        return b.build();
+    }
+
+    FilterType typeOf( Filter f ) {
+        return TYPE_MAP.get( f.getClass() );
+    }
+
+    FilterListType typeOf( FilterList f ) {
+        return LISTTYPE_MAP.get( f.getClass() );
     }
 
     private Iterable<Cursor.Position> positions() {

--- a/cursorpaging-jpa-api/src/main/proto/pagerequest.proto
+++ b/cursorpaging-jpa-api/src/main/proto/pagerequest.proto
@@ -15,6 +15,13 @@ enum Order {
   DESC = 1;
 }
 
+enum FilterType {
+  EQ = 0;
+  GT = 1;
+  LT = 2;
+  LIKE = 3;
+}
+
 message Position {
   Attribute attribute = 1;
   Value value = 2;
@@ -25,11 +32,32 @@ message Position {
 message Filter {
   Attribute attribute = 1;
   repeated Value values = 2;
+  optional FilterType type = 3;
+}
+
+message FilterList {
+  enum FilterListType {
+    AND = 0;
+    OR = 1;
+  }
+  optional FilterListType type = 1;
+  repeated Filter filters = 2;
+  repeated FilterList filter_lists = 3;
+}
+
+message Rule {
+  message Parameter {
+    string name = 1;
+    repeated Value values = 2;
+  }
+  string name = 1;
+  repeated Parameter parameters = 2;
 }
 
 message PageRequest {
   int32 page_size = 1;
-  repeated  Position positions = 2;
-  repeated  Filter filters = 3;
-  optional int64 total_count = 4;
+  repeated Position positions = 2;
+  optional FilterList filters = 3;
+  repeated Rule filter_rules = 4;
+  optional int64 total_count = 5;
 }

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/api/DtoPageRequestTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/api/DtoPageRequestTest.java
@@ -1,0 +1,128 @@
+package io.vigier.cursorpaging.jpa.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Order;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoAndFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoEqFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoFilterList;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoGtFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoLikeFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoLtFilter;
+import io.vigier.cursorpaging.jpa.api.DtoPageRequest.DtoOrFilter;
+import io.vigier.cursorpaging.jpa.filter.EqualFilter;
+import io.vigier.cursorpaging.jpa.filter.GreaterThanFilter;
+import io.vigier.cursorpaging.jpa.filter.LessThanFilter;
+import io.vigier.cursorpaging.jpa.filter.LikeFilter;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class DtoPageRequestTest {
+
+    @Test
+    void toPageRequest() {
+    }
+
+    @Test
+    void shouldDesrerializeFromJson() throws Exception {
+        String json = """
+                {
+                    "orderBy": {
+                        "id": "ASC"
+                    },
+                    "filterBy": {
+                        "AND": [
+                            {
+                                "GT": {
+                                    "id": [
+                                        "666"
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "pageSize": 10,
+                    "withTotalCount": false
+                }
+                """;
+
+        DtoPageRequest request = new ObjectMapper().readValue( json, DtoPageRequest.class );
+        assertThat( request.getOrderBy() ).containsExactly( Map.entry( "id", Order.ASC ) );
+        assertThat( request.getFilterBy() ).isNotNull().satisfies( fl -> {
+            assertThat( fl ).isInstanceOf( DtoAndFilter.class );
+            assertThat( ((DtoFilterList) fl).getFilters() ).hasSize( 1 ).first().satisfies( gtf -> {
+                assertThat( gtf ).isInstanceOf( DtoGtFilter.class );
+                assertThat( ((DtoGtFilter) gtf).getAttribute() ).isEqualTo( "id" );
+                assertThat( ((DtoGtFilter) gtf).getValues() ).contains( "666" );
+            } );
+        } );
+        assertThat( request.getPageSize() ).isEqualTo( 10 );
+
+    }
+
+    @Test
+    void shouldSerializeDtoPageRequestsToJson() throws JsonProcessingException {
+        var request = DtoPageRequest.builder()
+                .pageSize( 10 )
+                .orderBy( Map.of( "id", Order.ASC ) )
+                .filterBy( DtoAndFilter.builder()
+                        .filter( DtoGtFilter.builder().attribute( "id" ).value( "666" )
+                                .build() )
+                        .filter( DtoOrFilter.builder()
+                                .filter( DtoEqFilter.builder().attribute( "super" ).value( "true" )
+                                        .build() )
+                                .filter( DtoLikeFilter.builder().attribute( "name" ).value( "4711" )
+                                        .build() )
+                                .filter( DtoLtFilter.builder().attribute( "priority" ).value( "0815" )
+                                        .build() )
+                                .build() )
+                        .build() )
+                .build();
+
+        log.info( new ObjectMapper().writeValueAsString( request ) );
+    }
+
+    @Test
+    void shouldGenerateValidPageRequests() {
+        var request = DtoPageRequest.builder()
+                .pageSize( 10 )
+                .orderBy( Map.of( "id", Order.ASC ) )
+                .filterBy( DtoAndFilter.builder()
+                        .filter( DtoGtFilter.builder().attribute( "id" ).value( "666" )
+                                .build() )
+                        .filter( DtoOrFilter.builder()
+                                .filter( DtoEqFilter.builder().attribute( "super" ).value( "true" )
+                                        .build() )
+                                .filter( DtoLikeFilter.builder().attribute( "name" ).value( "4711" )
+                                        .build() )
+                                .filter( DtoLtFilter.builder().attribute( "priority" ).value( "0815" )
+                                        .build() )
+                                .build() )
+                        .build() )
+                .build();
+
+        var pageRequest = request.toPageRequest( s -> switch ( s ) {
+            case "id" -> Attribute.of( "id", Long.class );
+            case "super" -> Attribute.of( "super", Boolean.class );
+            case "name" -> Attribute.of( "name", String.class );
+            case "priority" -> Attribute.of( "priority", Integer.class );
+            default -> throw new IllegalArgumentException( "Unknown attribute: " + s );
+        } );
+
+        assertThat( pageRequest.pageSize() ).isEqualTo( 10 );
+        assertThat( pageRequest.filters() ).hasSize( 2 );
+        assertThat( pageRequest.filters().filters().get( 0 ) ).isInstanceOf( GreaterThanFilter.class );
+        assertThat( pageRequest.filters().filters().get( 1 ) ).isInstanceOf( OrFilter.class ).satisfies( of -> {
+            assertThat( ((OrFilter) of).filters() ).hasSize( 3 );
+            assertThat( ((OrFilter) of).filters().get( 0 ) ).isInstanceOf( EqualFilter.class );
+            assertThat( ((OrFilter) of).filters().get( 1 ) ).isInstanceOf( LikeFilter.class );
+            assertThat( ((OrFilter) of).filters().get( 2 ) ).isInstanceOf( LessThanFilter.class );
+        } );
+    }
+}

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/api/DtoPageRequestTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/api/DtoPageRequestTest.java
@@ -26,10 +26,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DtoPageRequestTest {
 
     @Test
-    void toPageRequest() {
-    }
-
-    @Test
     void shouldDesrerializeFromJson() throws Exception {
         String json = """
                 {

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/Base64StringTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/Base64StringTest.java
@@ -1,26 +1,26 @@
 package io.vigier.cursorpaging.jpa.serializer;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import jakarta.validation.ValidationException;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
 
-public class Base64StringTest {
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class Base64StringTest {
 
     @Test
     void shouldCreateValidBase64String() {
         final var encoded = Base64.getEncoder().encodeToString( "test".getBytes() );
         final var base64String = new Base64String( encoded );
-        assertThat( base64String.toString() ).isEqualTo( encoded );
+        assertThat( base64String ).hasToString( encoded );
     }
 
     @Test
     void shouldCreateValidBase64StringWithoutEqualsAtEnd() {
         final var encoded = Base64.getEncoder().encodeToString( "test".getBytes() ).replace( "=","" );
         final var base64String = new Base64String( encoded );
-        assertThat( base64String.toString() ).isEqualTo( encoded );
+        assertThat( base64String ).hasToString( encoded );
     }
 
     @Test

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/EncrypterTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/EncrypterTest.java
@@ -4,7 +4,7 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class EncrypterTest {
+class EncrypterTest {
 
     @Test
     @SneakyThrows

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
@@ -1,47 +1,92 @@
 package io.vigier.cursorpaging.jpa.serializer;
 
 import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.FilterRule;
+import io.vigier.cursorpaging.jpa.Filters;
 import io.vigier.cursorpaging.jpa.Order;
 import io.vigier.cursorpaging.jpa.PageRequest;
 import io.vigier.cursorpaging.jpa.Position;
+import io.vigier.cursorpaging.jpa.QueryBuilder;
 import io.vigier.cursorpaging.jpa.SingleAttribute;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.metamodel.SingularAttribute;
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.convert.ConversionService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
 
+@ExtendWith( MockitoExtension.class )
 public class SerializerTest {
 
     @Data
     private static class TestEntity {
 
+        private Long id;
         private String name;
     }
 
     private static class TestEntity_ {
 
         @SuppressWarnings( "unchecked" )
+        public static volatile SingularAttribute<TestEntity, Long> id = Mockito.mock( SingularAttribute.class );
+        @SuppressWarnings( "unchecked" )
         public static volatile SingularAttribute<TestEntity, String> name = Mockito.mock( SingularAttribute.class );
     }
 
+    @Mock
+    private ConversionService conversionService;
+
     @BeforeAll
     static void setup() {
-        Mockito.when( TestEntity_.name.getJavaType() ).thenReturn( String.class );
-        Mockito.when( TestEntity_.name.getName() ).thenReturn( "name" );
+        when( TestEntity_.name.getJavaType() ).thenReturn( String.class );
+        when( TestEntity_.name.getName() ).thenReturn( "name" );
+        lenient().when( TestEntity_.id.getJavaType() ).thenReturn( Long.class );
+        lenient().when( TestEntity_.id.getName() ).thenReturn( "id" );
     }
 
     @Test
     public void shouldSerializePageRequests() {
         final PageRequest<TestEntity> pageRequest = PageRequest.create( b -> b.desc( TestEntity_.name ) );
 
-        final EntitySerializer<TestEntity> serializer = EntitySerializer.create( b -> b.use( Attribute.of( TestEntity_.name ) ) );
+        final RequestSerializer<TestEntity> serializer = RequestSerializer.create(
+                b -> b.use( Attribute.of( TestEntity_.name ) ) );
         final var serializedRequest = serializer.toBytes( pageRequest );
         final var deserializeRequest = serializer.toPageRequest( serializedRequest );
-        
+
+        assertThat( deserializeRequest ).isEqualTo( pageRequest );
+    }
+
+    @Test
+    public void shouldSerializePageRequestsWithOrFilter() {
+        final PageRequest<TestEntity> pageRequest = PageRequest.create(
+                b -> b.desc( TestEntity_.name ).filter( Filters.or( //
+                        Filters.attribute( TestEntity_.name ).equalTo( "Name-1" ), //
+                        Filters.attribute( TestEntity_.id ).greaterThan( 1L ) //
+                ) ) );
+        when( conversionService.convert( anyString(), eq( Long.class ) ) ).thenAnswer(
+                i -> Long.valueOf( (String) i.getArguments()[0] ) );
+        when( conversionService.convert( anyString(), eq( String.class ) ) ).thenAnswer( i -> i.getArguments()[0] );
+
+        final RequestSerializer<TestEntity> serializer = RequestSerializer.create(
+                b -> b.use( Attribute.of( TestEntity_.name ) )
+                        .use( Attribute.of( TestEntity_.id ) )
+                        .conversionService( conversionService ) );
+        final var serializedRequest = serializer.toBytes( pageRequest );
+        final var deserializeRequest = serializer.toPageRequest( serializedRequest );
+
         assertThat( deserializeRequest ).isEqualTo( pageRequest );
     }
 
@@ -53,7 +98,7 @@ public class SerializerTest {
         final var attribute2 = Attribute.of( "three", Integer.class );
         final var pageRequest = PageRequest.create( b -> b.pageSize( 42 ).asc( attribute1 ).desc( attribute2 ) );
 
-        final var serializer = EntitySerializer.create( b -> b.use( attribute1 ).use( attribute2 ) );
+        final var serializer = RequestSerializer.create( b -> b.use( attribute1 ).use( attribute2 ) );
         final var serializedRequest = serializer.toBytes( pageRequest );
         final var deserializeRequest = serializer.toPageRequest( serializedRequest );
 
@@ -64,7 +109,7 @@ public class SerializerTest {
     void shouldSerializeReversedPageRequests() {
         final var request = PageRequest.create( r -> r.position( Position.create(
                 p -> p.reversed( true ).order( Order.ASC ).attribute( Attribute.of( "some_name", String.class ) ) ) ) );
-        final EntitySerializer<Object> serializer = EntitySerializer.create();
+        final RequestSerializer<Object> serializer = RequestSerializer.create();
         final var serializedRequest = serializer.toBase64( request );
         final var deserializedRequest = serializer.toPageRequest( serializedRequest );
         assertThat( deserializedRequest.isReversed() ).isTrue();
@@ -75,7 +120,7 @@ public class SerializerTest {
     @Test
     void shouldSerializeTotalCountIfPresent() {
         final var request = createPageRequest().copy( b -> b.enableTotalCount( true ).totalCount( 42L ) );
-        final EntitySerializer<TestEntity> serializer = EntitySerializer.create();
+        final RequestSerializer<TestEntity> serializer = RequestSerializer.create();
         final var serializedRequest = serializer.toBase64( request );
         final var deserializedRequest = serializer.toPageRequest( serializedRequest );
         assertThat( deserializedRequest ).isEqualTo( request ).satisfies( r -> {
@@ -85,9 +130,43 @@ public class SerializerTest {
     }
 
     @Test
+    void shouldSerializeParametersOfFilterRules() {
+        Map<String, List<String>> parameters = Map.of( "Test1", List.of( "Value1" ) );
+        final var request = createPageRequest().copy( b -> b.rule( newTestRule( "TestRule", parameters ) ) );
+        final RequestSerializer<TestEntity> serializer = RequestSerializer.create(
+                c -> c.filterRuleFactory( "TestRule", p -> newTestRule( "TestRule", p ) ) );
+        final var serializedRequest = serializer.toBase64( request );
+        final var deserializedRequest = serializer.toPageRequest( serializedRequest );
+
+        assertThat( deserializedRequest.rules() ).hasSize( 1 ).first().satisfies( r -> {
+            assertThat( r.name() ).isEqualTo( "TestRule" );
+            assertThat( r.parameters() ).containsEntry( "Test1", List.of( "Value1" ) );
+        } );
+    }
+
+    private FilterRule newTestRule( final String name, final Map<String, List<String>> parameters ) {
+        return new FilterRule() {
+            @Override
+            public Predicate toPredicate( final QueryBuilder cqb ) {
+                return null;
+            }
+
+            @Override
+            public String name() {
+                return name;
+            }
+
+            @Override
+            public Map<String, List<String>> parameters() {
+                return parameters;
+            }
+        };
+    }
+
+    @Test
     void shouldLearnAttributesBySerializing() {
         final var request = createPageRequest();
-        final EntitySerializer<TestEntity> serializer = EntitySerializer.create();
+        final RequestSerializer<TestEntity> serializer = RequestSerializer.create();
         final var serializedRequest = serializer.toBase64( request );
         final var deserializedRequest = serializer.toPageRequest( serializedRequest );
         assertThat( deserializedRequest ).isEqualTo( request );

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
@@ -58,7 +58,7 @@ public class SerializerTest {
     }
 
     @Test
-    public void shouldSerializePageRequests() {
+    void shouldSerializePageRequests() {
         final PageRequest<TestEntity> pageRequest = PageRequest.create( b -> b.desc( TestEntity_.name ) );
 
         final RequestSerializer<TestEntity> serializer = RequestSerializer.create(
@@ -70,7 +70,7 @@ public class SerializerTest {
     }
 
     @Test
-    public void shouldSerializePageRequestsWithOrFilter() {
+    void shouldSerializePageRequestsWithOrFilter() {
         final PageRequest<TestEntity> pageRequest = PageRequest.create(
                 b -> b.desc( TestEntity_.name ).filter( Filters.or( //
                         Filters.attribute( TestEntity_.name ).equalTo( "Name-1" ), //

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/SerializerTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith( MockitoExtension.class )
-public class SerializerTest {
+class SerializerTest {
 
     @Data
     private static class TestEntity {

--- a/cursorpaging-jpa/build.gradle.kts
+++ b/cursorpaging-jpa/build.gradle.kts
@@ -30,3 +30,9 @@ tasks.test {
     useJUnitPlatform()
 }
 
+tasks.jacocoTestReport {
+    reports {
+        xml.required = true
+    }
+}
+

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
@@ -58,7 +58,7 @@ public abstract class Filter implements QueryElement {
      * @param attribute Attribute (must not be `null`)
      * @param values the values used by the filter, must not be `null`, but can be empty or contain `null` or empty strings (which will be ignored)
      */
-    public Filter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+    protected Filter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
         this.attribute = attribute;
         this.values = values.stream()
                 .map( v -> v instanceof final CharSequence cs && !StringUtils.hasText( cs ) ? null : v )

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
@@ -1,19 +1,13 @@
 package io.vigier.cursorpaging.jpa;
 
+import io.vigier.cursorpaging.jpa.filter.FilterBuilder;
 import jakarta.persistence.criteria.Predicate;
-import jakarta.persistence.metamodel.SingularAttribute;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Singular;
-import lombok.With;
 import lombok.experimental.Accessors;
 import org.springframework.util.StringUtils;
 
@@ -23,15 +17,10 @@ import org.springframework.util.StringUtils;
  * Currently only simple attributes can be filtered (no collections, or nested properties). If the provided filter value
  * is a collection a one-must-match ("attribute in my-filter-values") logic applies.
  */
-@Builder( toBuilder = true )
 @Getter
 @Accessors( fluent = true )
 @EqualsAndHashCode
-public class Filter {
-
-    private enum Match {
-        EQUAL, LIKE, GREATER_THAN, LESS_THAN
-    }
+public abstract class Filter implements QueryElement {
 
     /**
      * The attribute to filter on.
@@ -41,121 +30,40 @@ public class Filter {
     /**
      * The value to filter on.
      */
-    @With
     @Singular
     private final List<? extends Comparable<?>> values;
 
-    @With
-    @Builder.Default
-    private final Match match = Match.EQUAL;
-
-    public static class FilterBuilder {
-
-        public FilterBuilder attribute( final SingularAttribute<?, ? extends Comparable<?>> attribute ) {
-            this.attribute = Attribute.of( attribute );
-            return this;
-        }
-
-        /**
-         * Creates an attribute as path to an embedded entity's property.
-         *
-         * @param attributes the path to the property
-         * @return the builder
-         */
-        @SafeVarargs
-        public final FilterBuilder path(
-                final jakarta.persistence.metamodel.Attribute<?, ? extends Comparable<?>>... attributes ) {
-            this.attribute = Attribute.path( attributes );
-            return this;
-        }
-
-        public FilterBuilder attribute( final Attribute attribute ) {
-            this.attribute = attribute;
-            return this;
-        }
-
-        public FilterBuilder like( final Comparable<?>... values ) {
-            match( Match.LIKE );
-            this.values = new ArrayList<>( Arrays.asList( values ) );
-            return this;
-        }
-
-        public FilterBuilder greaterThan( final Comparable<?>... values ) {
-            match( Match.GREATER_THAN );
-            this.values = new ArrayList<>( Arrays.asList( values ) );
-            return this;
-        }
-
-        public FilterBuilder lessThan( final Comparable<?>... values ) {
-            match( Match.LESS_THAN );
-            this.values = new ArrayList<>( Arrays.asList( values ) );
-            return this;
-        }
-
-        public Filter build() {
-            if ( attribute == null ) {
-                throw new NullPointerException( "Filter attribute must not be null!" );
-            }
-            return new Filter( attribute, values, match$set ? match$value : Match.EQUAL );
-        }
+    /**
+     * Get a new {@linkplain FilterBuilder}
+     *
+     * @return the builder
+     */
+    public static FilterBuilder builder() {
+        return new FilterBuilder();
     }
 
     /**
-     * Create a {@linkplain Filter} with a builder.
-     *
-     * @param creator the customizer for the builder
-     * @return a new {@linkplain Filter}
+     * Creator method to build a new Filter.
+     * @param c the consumer for the builder
+     * @return a new Filter instance
      */
-    public static Filter create( final Consumer<FilterBuilder> creator ) {
-        final var builder = Filter.builder();
-        creator.accept( builder );
+    public static Filter create( final Consumer<FilterBuilder> c ) {
+        FilterBuilder builder = builder();
+        c.accept( builder );
         return builder.build();
     }
 
     /**
-     * Create a {@linkplain Filter} on an attribute matching the given value(s).
-     *
-     * @param attribute the attribute to filter on
-     * @param values    the value(s) to filter for
-     * @return a new {@linkplain Filter}
+     * Constructs a Filter for the attribute and values.
+     * @param attribute Attribute (must not be `null`)
+     * @param values the values used by the filter, must not be `null`, but can be empty or contain `null` or empty strings (which will be ignored)
      */
-    public static Filter attributeIs( final SingularAttribute<?, ? extends Comparable<?>> attribute,
-            final Comparable<?>... values ) {
-        return attributeIs( Attribute.of( attribute ), values );
-    }
-
-    /**
-     * Create a {@linkplain Filter} on an attribute matching the given value(s).
-     *
-     * @param attribute the attribute to filter on
-     * @param values    the value(s) to filter for
-     * @return a new {@linkplain Filter}
-     */
-    public static Filter attributeIs( final SingularAttribute<?, ? extends Comparable<?>> attribute,
-            final Collection<Comparable<?>> values ) {
-        return attributeIs( Attribute.of( attribute ), values );
-    }
-
-    /**
-     * Create a {@linkplain Filter} on an attribute matching the given value(s).
-     *
-     * @param attribute the attribute to filter on
-     * @param values    the value(s) to filter for
-     * @return a new {@linkplain Filter}
-     */
-    public static Filter attributeIs( final Attribute attribute, final Comparable<?>... values ) {
-        return attributeIs( attribute, List.of( values ) );
-    }
-
-    /**
-     * Create a {@linkplain Filter} on an attribute matching the given value(s).
-     *
-     * @param attribute the attribute to filter on
-     * @param values    the value(s) to filter for
-     * @return a new {@linkplain Filter}
-     */
-    public static Filter attributeIs( final Attribute attribute, final Collection<Comparable<?>> values ) {
-        return Filter.create( b -> b.attribute( attribute ).values( values ) );
+    public Filter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+        this.attribute = attribute;
+        this.values = values.stream()
+                .map( v -> v instanceof final CharSequence cs && !StringUtils.hasText( cs ) ? null : v )
+                .filter( Objects::nonNull )
+                .toList();
     }
 
     <T extends Comparable<? super T>> List<T> values( Class<T> valueType ) {
@@ -164,72 +72,27 @@ public class Filter {
                 .toList();
     }
 
+    @Override
+    public List<Attribute> attributes() {
+        return List.of( attribute );
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
     /**
      * Apply the filter to the query builder
      *
      * @param qb the query builder
      */
-    public void apply( final QueryBuilder qb ) {
-        switch ( match ) {
-            case EQUAL -> applyEqual( qb );
-            case LIKE -> applyLike( qb );
-            case GREATER_THAN -> applyGreaterThan( qb );
-            case LESS_THAN -> applyLessThan( qb );
+    public Predicate toPredicate( final QueryBuilder qb ) {
+        if ( !values.isEmpty() ) {
+            return toFilterPredicate( qb, values );
         }
+        return qb.cb().and();
     }
 
-    private void applyLike( final QueryBuilder qb ) {
-        final List<Predicate> predicates = values.stream()
-                .filter( Objects::nonNull )
-                .map( Object::toString )
-                .filter( StringUtils::hasText )
-                .map( v -> qb.isLike( attribute, v ) )
-                .toList();
-        if ( predicates.size() > 1 ) {
-            qb.andWhere( qb.orOne( predicates ) );
-        } else if ( predicates.size() == 1 ) {
-            qb.andWhere( predicates.get( 0 ) );
-        }
-    }
-
-    private void applyGreaterThan( final QueryBuilder qb ) {
-        final List<Predicate> predicates = values.stream()
-                .filter( Objects::nonNull )
-                .map( v -> qb.greaterThan( attribute, v ) )
-                .toList();
-        if ( predicates.size() > 1 ) {
-            qb.andWhere( qb.orOne( predicates ) );
-        } else if ( predicates.size() == 1 ) {
-            qb.andWhere( predicates.get( 0 ) );
-        }
-    }
-
-    private void applyLessThan( final QueryBuilder qb ) {
-        final List<Predicate> predicates = values.stream()
-                .filter( Objects::nonNull )
-                .map( v -> qb.lessThan( attribute, v ) )
-                .toList();
-        if ( predicates.size() > 1 ) {
-            qb.andWhere( qb.orOne( predicates ) );
-        } else if ( predicates.size() == 1 ) {
-            qb.andWhere( predicates.get( 0 ) );
-        }
-    }
-
-    private void applyEqual( final QueryBuilder qb ) {
-        final List<? extends Comparable<?>> filterValues = values.stream()
-                .filter( Objects::nonNull )
-                .collect( Collectors.toList() );
-        if ( filterValues.size() > 1 ) {
-            qb.andWhere( qb.isIn( attribute, filterValues ) );
-        } else if ( filterValues.size() == 1 ) {
-            qb.andWhere( qb.equalTo( attribute, filterValues.get( 0 ) ) );
-        }
-    }
-
-    public boolean isEmpty() {
-        return values.isEmpty() || values.stream()
-                .allMatch( v -> Objects.isNull( v ) || (v instanceof final CharSequence cs && !StringUtils.hasText(
-                        cs )) );
-    }
+    protected abstract Predicate toFilterPredicate( final QueryBuilder qb, List<? extends Comparable<?>> cleanValues );
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/FilterRule.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/FilterRule.java
@@ -1,20 +1,14 @@
 package io.vigier.cursorpaging.jpa;
 
 import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+import java.util.Map;
 
 
 /**
  * A custom rule to filter the query.
  */
-public interface FilterRule {
-
-    default void applyQuery( final QueryBuilder cqb ) {
-        cqb.andWhere( getPredicate( cqb ) );
-    }
-
-    default void applyCount( final QueryBuilder cqb ) {
-        cqb.andWhere( getCountPredicate( cqb ) );
-    }
+public interface FilterRule extends QueryElement {
 
     /**
      * Sometimes the query-predicate must be different than the count-predicate due to the criteria API
@@ -22,15 +16,25 @@ public interface FilterRule {
      * @param cqb Query, Builder and Root
      * @return the predicate which should be applied to the where-clause
      */
-    default Predicate getCountPredicate( final QueryBuilder cqb ) {
-        return getPredicate( cqb );
+    default Predicate toCountPredicate( final QueryBuilder cqb ) {
+        return toPredicate( cqb );
     }
 
-    /**
-     * Get the predicate for the query.
-     *
-     * @param cqb Query, Builder and Root
-     * @return the predicate which should be applied to the where-clause
-     */
-    Predicate getPredicate( final QueryBuilder cqb );
+    @Override
+    default List<Attribute> attributes() {
+        return List.of();
+    }
+
+    @Override
+    default boolean isEmpty() {
+        return false;
+    }
+
+    default String name() {
+        return this.getClass().getName();
+    }
+
+    default Map<String, List<String>> parameters() {
+        return Map.of();
+    }
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
@@ -114,6 +114,9 @@ public final class Filters {
         }
     }
 
+    private Filters() {
+    }
+    
     /**
      * Starts a filter-creation with the provided attribute
      *

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
@@ -1,0 +1,216 @@
+package io.vigier.cursorpaging.jpa;
+
+import io.vigier.cursorpaging.jpa.filter.AndFilter;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
+import jakarta.persistence.metamodel.SingularAttribute;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+public final class Filters {
+
+    @RequiredArgsConstructor( staticName = "create" )
+    public static class FilterCreator {
+
+        private final Attribute attribute;
+
+        /**
+         * equal expression
+         *
+         * @param value the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter equalTo( Comparable<?> value ) {
+            return Filter.create( f -> f.attribute( attribute ).equalTo( value ) );
+        }
+
+        /**
+         * equal/in expression
+         *
+         * @param values the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter equalTo( List<? extends Comparable<?>> values ) {
+            return Filter.create( f -> f.attribute( attribute ).equalTo( values ) );
+        }
+
+        /**
+         * in expression
+         *
+         * @param values the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter in( List<? extends Comparable<?>> values ) {
+            return Filter.create( f -> f.attribute( attribute ).in( values ) );
+        }
+
+        /**
+         * in expression
+         *
+         * @param values the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter in( Comparable<?>... values ) {
+            return Filter.create( f -> f.attribute( attribute ).in( values ) );
+        }
+
+        /**
+         * like-in expression
+         *
+         * @param values the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter like( String... values ) {
+            return Filter.create( f -> f.attribute( attribute ).like( values ) );
+        }
+
+        /**
+         * like-in expression
+         *
+         * @param values the value to compare to
+         * @return the filter for the operation
+         */
+        public Filter like( List<? extends Comparable<?>> values ) {
+            return Filter.create( f -> f.attribute( attribute ).like( values ) );
+        }
+
+        /**
+         * Filter to select all values greater-than the given one.
+         *
+         * @param value The value to compare to
+         * @return A filter for the operation
+         */
+        public Filter greaterThan( Comparable<?> value ) {
+            return Filter.create( f -> f.attribute( attribute ).greaterThan( value ) );
+        }
+
+        /**
+         * Greater than with multiple values means greaterThan max of all values
+         *
+         * @param values values to compare
+         * @return the filter
+         */
+        public Filter greaterThan( final List<? extends Comparable<?>> values ) {
+            return Filter.create( f -> f.attribute( attribute ).greaterThan( values ) );
+        }
+
+        /**
+         * Filter to select all values less-than the given one.
+         *
+         * @param value The value to compare to
+         * @return A filter for the operation
+         */
+        public Filter lessThan( Comparable<?> value ) {
+            return Filter.create( f -> f.attribute( attribute ).lessThan( value ) );
+        }
+
+        /**
+         * Less than with multiple values means lessThan the minimum of all values
+         *
+         * @param values values to compare
+         * @return A filter for the operation
+         */
+        public Filter lessThan( List<? extends Comparable<?>> values ) {
+            return Filter.create( f -> f.attribute( attribute ).lessThan( values ) );
+        }
+    }
+
+    /**
+     * Starts a filter-creation with the provided attribute
+     *
+     * @param attribute to be filtered on
+     * @return the filter creator for the operation
+     */
+    public static FilterCreator attribute( final Attribute attribute ) {
+        return FilterCreator.create( attribute );
+    }
+
+    /**
+     * Starts a filter-creation with the provided attribute
+     *
+     * @param name of the attribute to be filtered on
+     * @param type of the attribute to be filtered on
+     * @return the filter creator for the operation
+     */
+    public static FilterCreator attribute( final String name, Class<? extends Comparable<?>> type ) {
+        return FilterCreator.create( Attribute.of( name, type ) );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes
+     *
+     * @param name1 of the first attribute in the path
+     * @param type1 of the first attribute in the path
+     * @param name2 of the second attribute in the path
+     * @param type2 of the second attribute in the path
+     * @return the filter creator for the operation
+     */
+    public static FilterCreator attribute( final String name1, Class<? extends Comparable<?>> type1, String name2,
+            Class<? extends Comparable<?>> type2 ) {
+        return FilterCreator.create( Attribute.path( name1, type1, name2, type2 ) );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes
+     */
+    public static FilterCreator attribute( final jakarta.persistence.metamodel.Attribute<?, ?>... path ) {
+        return attribute( Attribute.path( path ) );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes
+     */
+    public static FilterCreator attribute( final SingularAttribute<?, ? extends Comparable<?>> attribute ) {
+        return attribute( Attribute.of( attribute ) );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes, ignoring the case in the subsequent operations.
+     */
+    public static FilterCreator ignoreCase( final Attribute attribute ) {
+        return FilterCreator.create( attribute.withIgnoreCase() );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes, ignoring the case in the subsequent operations.
+     */
+    public static FilterCreator ignoreCase( final jakarta.persistence.metamodel.Attribute<?, ?>... path ) {
+        return ignoreCase( Attribute.path( path ) );
+    }
+
+    /**
+     * Starts filter-creation with a path of the provided attributes, ignoring the case in the subsequent operations.
+     */
+    public static FilterCreator ignoreCase( final SingularAttribute<?, ? extends Comparable<?>> attribute ) {
+        return ignoreCase( Attribute.of( attribute ) );
+    }
+
+    /**
+     * Create in filter combining the given filters by 'or'
+     *
+     * @param filters the filters to combine
+     * @return the combined filter
+     */
+    public static OrFilter or( final QueryElement... filters ) {
+        return OrFilter.of( filters );
+    }
+
+    /**
+     * Create in filter combining the given filters by 'and'
+     *
+     * @param filters the filters to combine
+     * @return the combined filter
+     */
+    public static AndFilter and( final QueryElement... filters ) {
+        return AndFilter.of( filters );
+    }
+
+    /**
+     * Create in filter combining the given filters by 'and'
+     *
+     * @param filters the filters to combine
+     * @return the combined filter
+     */
+    public static AndFilter and( final List<QueryElement> filters ) {
+        return AndFilter.of( filters );
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
@@ -198,6 +198,16 @@ public final class Filters {
     }
 
     /**
+     * Create in filter combining the given filters by 'or'
+     *
+     * @param filters the filters to combine
+     * @return the combined filter
+     */
+    public static OrFilter or( final List<QueryElement> filters ) {
+        return OrFilter.of( filters );
+    }
+
+    /**
      * Create in filter combining the given filters by 'and'
      *
      * @param filters the filters to combine

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
@@ -2,6 +2,7 @@ package io.vigier.cursorpaging.jpa;
 
 import io.vigier.cursorpaging.jpa.filter.AndFilter;
 import io.vigier.cursorpaging.jpa.filter.FilterList;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
 import jakarta.persistence.Transient;
 import jakarta.persistence.metamodel.SingularAttribute;
 import java.util.ArrayList;
@@ -49,7 +50,7 @@ public class PageRequest<E> {
      * The filters to apply to the query (removing results)
      */
     @Builder.Default
-    private final AndFilter filters = AndFilter.of();
+    private final FilterList filters = AndFilter.of();
 
     /**
      * The filter rules to apply to the query (removing results). Note that filter rules are <i>not</i> passed to the
@@ -168,7 +169,7 @@ public class PageRequest<E> {
             if ( filter != null && !filter.isEmpty() ) {
                 filters.add( filter );
             }
-            this.filters$value = AndFilter.of( filters );
+            this.filters$value = (filters$value instanceof OrFilter ? OrFilter.of( filters ) : AndFilter.of( filters ));
             this.filters$set = true;
             return this;
         }
@@ -182,11 +183,8 @@ public class PageRequest<E> {
          */
         public PageRequestBuilder<E> filters( final FilterList filters ) {
             if ( filters != null ) {
-                if ( filters instanceof AndFilter || filters.size() == 1 ) {
-                    filters.forEach( this::filter );
-                } else {
-                    filter( filters );
-                }
+                this.filters$value = filters;
+                this.filters$set = true;
             }
             return this;
         }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
@@ -134,6 +134,4 @@ public interface QueryBuilder {
      * @param order     the order (ASC or DESC)
      */
     void orderBy( Attribute attribute, Order order );
-
-    Predicate orOne( List<Predicate> predicates );
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryElement.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryElement.java
@@ -1,0 +1,13 @@
+package io.vigier.cursorpaging.jpa;
+
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+
+public interface QueryElement {
+
+    Predicate toPredicate( QueryBuilder cqb );
+
+    List<Attribute> attributes();
+
+    boolean isEmpty();
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/AndFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/AndFilter.java
@@ -1,0 +1,38 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import io.vigier.cursorpaging.jpa.QueryElement;
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors( fluent = true )
+@EqualsAndHashCode( callSuper = true )
+public class AndFilter extends FilterList {
+
+    protected AndFilter( final List<QueryElement> filters ) {
+        super( filters );
+    }
+
+    @Override
+    public Predicate toPredicate( final QueryBuilder cqb ) {
+        if ( !filters().isEmpty() ) {
+            if ( filters().size() > 1 ) {
+                return cqb.cb().and( filters().stream().map( f -> f.toPredicate( cqb ) ).toArray( Predicate[]::new ) );
+            }
+            return filters().get( 0 ).toPredicate( cqb );
+        }
+        return cqb.cb().and();
+    }
+
+    public static AndFilter of( final QueryElement... filters ) {
+        return new AndFilter( List.of( filters ) );
+    }
+
+    public static AndFilter of( final List<QueryElement> filters ) {
+        return new AndFilter( filters );
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/EqualFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/EqualFilter.java
@@ -1,0 +1,23 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+
+
+public class EqualFilter extends Filter {
+
+    public EqualFilter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+        super( attribute, values );
+    }
+
+    @Override
+    protected Predicate toFilterPredicate( final QueryBuilder qb, final List<? extends Comparable<?>> cleanValues ) {
+        if ( cleanValues.size() > 1 ) {
+            return qb.isIn( attribute(), cleanValues );
+        }
+        return qb.equalTo( attribute(), cleanValues.get( 0 ) );
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterBuilder.java
@@ -1,0 +1,124 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import jakarta.persistence.metamodel.SingularAttribute;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class FilterBuilder {
+
+    public enum FilterType {
+        EQUAL, GREATER_THAN, LESS_THAN, LIKE
+    }
+
+    private FilterType filterType;
+    private Attribute attribute;
+    private List<Comparable<?>> values = new ArrayList<>();
+
+    public FilterBuilder attribute( final SingularAttribute<?, ? extends Comparable<?>> attribute ) {
+        this.attribute = Attribute.of( attribute );
+        return this;
+    }
+
+    public FilterBuilder attribute( final Attribute attribute ) {
+        this.attribute = attribute;
+        return this;
+    }
+
+    /**
+     * Creates an attribute as path to an embedded entity's property.
+     *
+     * @param attributes the path to the property
+     * @return the builder
+     */
+    @SafeVarargs
+    public final FilterBuilder path(
+            final jakarta.persistence.metamodel.Attribute<?, ? extends Comparable<?>>... attributes ) {
+        this.attribute = Attribute.path( attributes );
+        return this;
+    }
+
+    public FilterBuilder equalTo( final Comparable<?> value ) {
+        this.values( value );
+        this.filterType = FilterType.EQUAL;
+        return this;
+    }
+
+    /**
+     * Same as {@linkplain #in(List)} )}
+     *
+     * @param values List of allowed values to be equal to
+     * @return the builder
+     */
+    public FilterBuilder equalTo( final List<? extends Comparable<?>> values ) {
+        return in( values );
+    }
+
+    public FilterBuilder in( final Comparable<?>... values ) {
+        return in( Arrays.asList( values ) );
+    }
+
+    public FilterBuilder in( final List<? extends Comparable<?>> values ) {
+        values( values );
+        this.filterType = FilterType.EQUAL;
+        return this;
+    }
+
+    public FilterBuilder like( final Comparable<?>... values ) {
+        return like( Arrays.asList( values ) );
+    }
+
+    public FilterBuilder like( final List<? extends Comparable<?>> values ) {
+        this.values( values );
+        this.filterType = FilterType.LIKE;
+        return this;
+    }
+
+    public FilterBuilder greaterThan( final Comparable<?>... values ) {
+        return greaterThan( Arrays.asList( values ) );
+    }
+
+    public FilterBuilder greaterThan( final List<? extends Comparable<?>> values ) {
+        this.values( values );
+        this.filterType = FilterType.GREATER_THAN;
+        return this;
+    }
+
+    public FilterBuilder lessThan( final Comparable<?>... values ) {
+        return lessThan( Arrays.asList( values ) );
+    }
+
+    public FilterBuilder lessThan( final List<? extends Comparable<?>> values ) {
+        this.values( values );
+        this.filterType = FilterType.LESS_THAN;
+        return this;
+    }
+
+    public FilterBuilder values( final Comparable<?>... values ) {
+        return values( Arrays.asList( values ) );
+    }
+
+    public FilterBuilder values( final List<? extends Comparable<?>> values ) {
+        this.values = (values != null ? new ArrayList<>( values ) : List.of());
+        return this;
+    }
+
+    public FilterBuilder type( final FilterType filterType ) {
+        this.filterType = filterType;
+        return this;
+    }
+
+    public Filter build() {
+        if ( filterType == null ) {
+            throw new IllegalStateException( "No operation/value specificed" );
+        }
+        return switch ( filterType ) {
+            case EQUAL -> new EqualFilter( attribute, values );
+            case GREATER_THAN -> new GreaterThanFilter( attribute, values );
+            case LESS_THAN -> new LessThanFilter( attribute, values );
+            case LIKE -> new LikeFilter( attribute, values );
+        };
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterList.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterList.java
@@ -1,0 +1,50 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.QueryElement;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Consumer;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors( fluent = true )
+@EqualsAndHashCode
+public abstract class FilterList implements QueryElement, Iterable<QueryElement> {
+
+    private final List<QueryElement> filters;
+
+    protected FilterList( final List<QueryElement> filters ) {
+        this.filters = List.copyOf( filters );
+    }
+
+    @Override
+    public List<Attribute> attributes() {
+        return filters.stream().flatMap( e -> e.attributes().stream() ).toList();
+    }
+
+    /**
+     * Returns an iterator over elements within the filter-list.
+     *
+     * @return an Iterator.
+     */
+    @Override
+    public Iterator<QueryElement> iterator() {
+        return filters.iterator();
+    }
+
+    @Override
+    public void forEach( final Consumer<? super QueryElement> action ) {
+        filters.forEach( action );
+    }
+
+    public int size() {
+        return filters.size();
+    }
+
+    public boolean isEmpty() {
+        return filters.isEmpty();
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/GreaterThanFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/GreaterThanFilter.java
@@ -1,0 +1,24 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+
+public class GreaterThanFilter extends Filter {
+
+    public GreaterThanFilter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+        super( attribute, values );
+    }
+
+    @Override
+    protected Predicate toFilterPredicate( final QueryBuilder qb, final List<? extends Comparable<?>> cleanValues ) {
+        final List<Predicate> predicates = cleanValues.stream().map( v -> qb.greaterThan( attribute(), v ) ).toList();
+        if ( predicates.size() > 1 ) {
+            return qb.cb().and( predicates.toArray( Predicate[]::new ) );
+        }
+        return predicates.get( 0 );
+    }
+
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/LessThanFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/LessThanFilter.java
@@ -1,0 +1,24 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+
+public class LessThanFilter extends Filter {
+
+    public LessThanFilter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+        super( attribute, values );
+    }
+
+    @Override
+    protected Predicate toFilterPredicate( final QueryBuilder qb, final List<? extends Comparable<?>> cleanValues ) {
+        final List<Predicate> predicates = cleanValues.stream().map( v -> qb.lessThan( attribute(), v ) ).toList();
+        if ( predicates.size() > 1 ) {
+            return qb.cb().and( predicates.toArray( Predicate[]::new ) );
+        }
+        return predicates.get( 0 );
+    }
+
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/LikeFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/LikeFilter.java
@@ -1,0 +1,27 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import jakarta.persistence.criteria.Predicate;
+import java.util.List;
+
+public class LikeFilter extends Filter {
+
+    public LikeFilter( final Attribute attribute, final List<? extends Comparable<?>> values ) {
+        super( attribute, values );
+    }
+
+    @Override
+    protected Predicate toFilterPredicate( final QueryBuilder qb, final List<? extends Comparable<?>> cleanValues ) {
+        final var predicates = cleanValues.stream()
+                .map( Object::toString )
+                .map( v -> qb.isLike( attribute(), v ) )
+                .toArray( Predicate[]::new );
+        if ( predicates.length > 1 ) {
+            return qb.cb().or( predicates );
+        }
+        return predicates[0];
+    }
+
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/OrFilter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/OrFilter.java
@@ -1,0 +1,39 @@
+package io.vigier.cursorpaging.jpa.filter;
+
+import io.vigier.cursorpaging.jpa.QueryBuilder;
+import io.vigier.cursorpaging.jpa.QueryElement;
+import jakarta.persistence.criteria.Predicate;
+import java.util.Collection;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Getter
+@Accessors( fluent = true )
+@EqualsAndHashCode( callSuper = true )
+public class OrFilter extends FilterList {
+
+    private OrFilter( final List<QueryElement> filters ) {
+        super( filters );
+    }
+
+    @Override
+    public Predicate toPredicate( final QueryBuilder cqb ) {
+        if ( !isEmpty() ) {
+            if ( size() > 1 ) {
+                return cqb.cb().or( filters().stream().map( f -> f.toPredicate( cqb ) ).toArray( Predicate[]::new ) );
+            }
+            return filters().get( 0 ).toPredicate( cqb );
+        }
+        return cqb.cb().and();
+    }
+
+    public static OrFilter of( final QueryElement... filters ) {
+        return new OrFilter( List.of( filters ) );
+    }
+
+    public static OrFilter of( final Collection<QueryElement> filters ) {
+        return new OrFilter( List.copyOf( filters ) );
+    }
+}

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
@@ -8,6 +8,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -132,21 +133,23 @@ public class CriteriaQueryBuilder<E, R> implements QueryBuilder {
         return cb.like( attribute.path( root ), value );
     }
 
-    @Override
-    public Predicate orOne( final List<Predicate> predicates ) {
-        return cb.or( predicates.toArray( new Predicate[0] ) );
-    }
-
     private void addWhere( final List<Predicate> conditions, final AppendMode appendMode ) {
         final var restriction = query.getRestriction();
         if ( restriction == null ) {
             query.where( conditions.toArray( new Predicate[0] ) );
         } else {
             switch ( appendMode ) {
-                case AND -> query.where( cb.and( conditions.toArray( new Predicate[0] ) ) );
+                case AND -> query.where( cb.and( listOf( restriction, conditions ).toArray( new Predicate[0] ) ) );
                 case OR -> query.where( cb.or( restriction, cb.and( conditions.toArray( new Predicate[0] ) ) ) );
             }
         }
+    }
+
+    private static List<Predicate> listOf( final Predicate restriction, final List<Predicate> conditions ) {
+        List<Predicate> allConditions = new ArrayList<>( conditions.size() + 1 );
+        allConditions.add( restriction );
+        allConditions.addAll( conditions );
+        return allConditions;
     }
 
     @Override

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
@@ -59,8 +59,8 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
             }
             cqb.orderBy( position.attribute(), position.order() );
         } );
-        request.filters().forEach( filter -> filter.apply( cqb ) );
-        request.rules().forEach( rule -> rule.applyQuery( cqb ) );
+        cqb.andWhere( request.filters().toPredicate( cqb ) );
+        request.rules().forEach( rule -> cqb.andWhere( rule.toPredicate( cqb ) ) );
 
         final var results = entityManager.createQuery( cqb.query().distinct( true ) )
                 .setMaxResults( getMaxResultSize( request ) )
@@ -79,8 +79,8 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
         final CriteriaQueryBuilder<E, Long> cqb = CriteriaQueryBuilder.forCount( entityInformation.getJavaType(),
                 entityManager );
 
-        request.filters().forEach( filter -> filter.apply( cqb ) );
-        request.rules().forEach( rule -> rule.applyCount( cqb ) );
+        request.filters().forEach( filter -> cqb.andWhere( filter.toPredicate( cqb ) ) );
+        request.rules().forEach( rule -> cqb.andWhere( rule.toCountPredicate( cqb ) ) );
 
         return entityManager.createQuery( cqb.query() ).getSingleResult();
     }

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/AutoConfigurationTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/AutoConfigurationTest.java
@@ -14,7 +14,7 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 @ExtendWith( MockitoExtension.class )
-public class AutoConfigurationTest {
+class AutoConfigurationTest {
 
     @Mock
     private EntityManager entityManager;
@@ -40,8 +40,7 @@ public class AutoConfigurationTest {
 
     @Test
     void shouldLoadWhenEntityManagerIsPresent() {
-        enabledContextRunner.run( context -> {
-            Assertions.assertThat( context ).hasSingleBean( CursorPageAutoConfigure.class );
-        } );
+        enabledContextRunner.run(
+                context -> Assertions.assertThat( context ).hasSingleBean( CursorPageAutoConfigure.class ) );
     }
 }

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FilterTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FilterTest.java
@@ -2,7 +2,9 @@ package io.vigier.cursorpaging.jpa;
 
 import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
 import io.vigier.cursorpaging.jpa.itest.model.DataRecord_;
+import io.vigier.cursorpaging.jpa.itest.model.Tag_;
 import jakarta.persistence.metamodel.SingularAttribute;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,32 +25,44 @@ class FilterTest {
         Mockito.when( nameAttrMock.getName() ).thenReturn( "name" );
         Mockito.when( nameAttrMock.getJavaType() ).thenReturn( String.class );
         DataRecord_.name = nameAttrMock;
-        final var sut = Filter.attributeIs( DataRecord_.name, value );
-        verifyNameAndValue( sut, DataRecord_.NAME, value );
+        final var sut = Filter.create( f -> f.attribute( DataRecord_.name ).equalTo( value ) );
+        verifyNameAndValue( sut, DataRecord_.NAME, String.class, value );
     }
 
     @Test
     void shouldCreateFilterFromManualSpecifiedAttribute() {
         final var value = "test";
-        final var sut = Filter.attributeIs( Attribute.of( DataRecord_.NAME, String.class ), value );
-        verifyNameAndValue( sut, DataRecord_.NAME, value );
+        final var sut = Filter.create(
+                f -> f.attribute( Attribute.of( DataRecord_.NAME, String.class ) ).equalTo( value ) );
+        verifyNameAndValue( sut, DataRecord_.NAME, String.class, value );
     }
 
     @Test
     void shouldCreateFilterFromManualSpecifiedAttributeWithMultipleValues() {
         final String[] values = { "test", "test2" };
-        final var sut = Filter.attributeIs( Attribute.of( DataRecord_.NAME, String.class ), values );
-        verifyNameAndValue( sut, DataRecord_.NAME, values );
+        final var sut = Filter.create(
+                f -> f.attribute( Attribute.of( DataRecord_.NAME, String.class ) ).in( values ) );
+        verifyNameAndValue( sut, DataRecord_.NAME, String.class, values );
     }
 
+    @Test
+    void shouldCreateFilterFromPath() {
+        Long value = 4711L;
+        final var sut = Filter.create(
+                f -> f.attribute( Attribute.path( DataRecord_.TAGS, Set.class, Tag_.ID, Long.class ) )
+                        .equalTo( value ) );
+        verifyNameAndValue( sut, DataRecord_.TAGS + "." + Tag_.ID, Long.class, value );
+    }
 
-    private static void verifyNameAndValue( final Filter sut, final String name, final String... values ) {
+    @SafeVarargs
+    private static <E extends Comparable<? super E>> void verifyNameAndValue( final Filter sut, final String name,
+            final Class<E> type, final E... values ) {
         assertThat( sut ).isNotNull().satisfies( f -> {
             assertThat( f.attribute() ).isNotNull().satisfies( a -> {
                 assertThat( a.name() ).isEqualTo( name );
-                assertThat( a.type() ).isEqualTo( String.class );
+                assertThat( a.type() ).isEqualTo( type );
             } );
-            assertThat( f.values( String.class ) ).containsExactly( values );
+            assertThat( f.values( type ) ).containsExactly( values );
         } );
     }
 }

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FiltersTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/FiltersTest.java
@@ -1,0 +1,65 @@
+package io.vigier.cursorpaging.jpa;
+
+import io.vigier.cursorpaging.jpa.itest.model.DataRecord;
+import io.vigier.cursorpaging.jpa.itest.model.DataRecord_;
+import io.vigier.cursorpaging.jpa.itest.model.Tag;
+import io.vigier.cursorpaging.jpa.itest.model.Tag_;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.metamodel.SetAttribute;
+import jakarta.persistence.metamodel.SingularAttribute;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith( MockitoExtension.class )
+class FiltersTest {
+
+    @Mock
+    private SingularAttribute<DataRecord, String> name;
+
+    @Mock
+    private SetAttribute<DataRecord, Tag> tags;
+
+    @Mock
+    private SingularAttribute<Tag, String> tagName;
+
+    @Mock
+    Predicate predicate;
+
+    @BeforeEach
+    void setup() {
+        lenient().when( name.getName() ).thenReturn( "name" );
+        lenient().when( name.getJavaType() ).thenReturn( String.class );
+        DataRecord_.name = name;
+        DataRecord_.tags = tags;
+        Tag_.name = tagName;
+    }
+
+    @Test
+    void shouldGenerateEqualsFilter() {
+        final var filter = Filters.attribute( DataRecord_.name ).equalTo( "Test" );
+        assertThat( filter.attributes() ).contains( Attribute.of( name ) );
+        assertThat( filter.values().get( 0 ) ).isEqualTo( "Test" );
+    }
+
+    @Test
+    void shouldGeneratePathFilterWithIgnoreCase() {
+        when( tags.getName() ).thenReturn( "tags" );
+        when( tagName.getName() ).thenReturn( "name" );
+        when( tagName.getJavaType() ).thenReturn( String.class );
+
+        List<String> values = List.of( "Test1", "Test2" );
+        final var filter = Filters.ignoreCase( DataRecord_.tags, Tag_.name ).in( values );
+        assertThat( filter.attributes() ).contains( Attribute.path( DataRecord_.tags, Tag_.name ).withIgnoreCase() );
+
+        assertThat( filter.values() ).hasSize( values.size() );
+        assertThat( filter.values( String.class ) ).containsAll( values );
+    }
+}

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
@@ -14,7 +14,7 @@ public class PageRequestTest {
     @ValueSource( strings = { "  ", "\t", "\n" } )
     void shouldIgnoreEmptyFilter( final String value ) {
         final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
-                .filter( Filter.create( f -> f.attribute( Attribute.of( "test", String.class ) ).value( value ) ) ) );
+                .filter( Filter.create( f -> f.attribute( Attribute.of( "test", String.class ) ).equalTo( value ) ) ) );
 
         assertThat( pageRequest.filters() ).isEmpty();
     }
@@ -22,7 +22,7 @@ public class PageRequestTest {
     @Test
     void shouldAddPositionAndFilterIfValuePresent() {
         final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
-                .filter( Filter.create( f -> f.attribute( Attribute.of( "test", String.class ) ).value( "value" ) ) ) );
+                .filter( Filters.attribute( "test", String.class ).equalTo( "value" ) ) );
 
         assertThat( pageRequest.filters() ).hasSize( 1 );
         assertThat( pageRequest.positions() ).hasSize( 1 ).first().satisfies( p -> {

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PageRequestTest {
+class PageRequestTest {
 
     @ParameterizedTest
     @NullAndEmptySource

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
@@ -68,7 +68,7 @@ class PostgreSqlCursorPageTest {
     @Test
     void contextLoads() {
         final var factoryBeans = applicationContext.getBeansOfType( CursorPageRepositoryFactoryBean.class );
-        assertThat( factoryBeans.size() ).isPositive(); // I.e. one per repository
+        assertThat( factoryBeans ).isNotEmpty(); // I.e. one per repository
     }
 
 

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
@@ -68,7 +68,7 @@ class PostgreSqlCursorPageTest {
     @Test
     void contextLoads() {
         final var factoryBeans = applicationContext.getBeansOfType( CursorPageRepositoryFactoryBean.class );
-        assertThat( factoryBeans.size() ).isGreaterThanOrEqualTo( 1 ); // I.e. one per repository
+        assertThat( factoryBeans.size() ).isPositive(); // I.e. one per repository
     }
 
 
@@ -108,11 +108,12 @@ class PostgreSqlCursorPageTest {
 
         final var firstPage = dataRecordRepository.loadPage( request );
         assertThat( firstPage ).isNotNull().hasSize( 10 );
+
         final var next = firstPage.next();
         assertThat( next ).isPresent();
+
         final var nextPage = dataRecordRepository.loadPage( next.get().withPageSize( 20 ) );
-        assertThat( nextPage ).isNotNull().hasSize( 20 );
-        assertThat( nextPage ).doesNotContainAnyElementsOf( firstPage );
+        assertThat( nextPage ).isNotNull().hasSize( 20 ).doesNotContainAnyElementsOf( firstPage );
         assertThat( nextPage.next() ).isEmpty();
     }
 
@@ -360,7 +361,7 @@ class PostgreSqlCursorPageTest {
 
         final var count = dataRecordRepository.count( request );
 
-        assertThat( count ).isEqualTo( 0 );
+        assertThat( count ).isZero();
     }
 
     private static class OnlyPublicFilterRule implements FilterRule {
@@ -555,7 +556,7 @@ class PostgreSqlCursorPageTest {
     }
 
     @Test
-    public void shouldUseMoreComplicateFilterRulesForAclChecks() {
+    void shouldUseMoreComplicateFilterRulesForAclChecks() {
         testDataGenerator.generateData( 100 );
         final PageRequest<DataRecord> request = PageRequest.create( b -> b.pageSize( 100 )
                 .desc( Attribute.path( DataRecord_.auditInfo, AuditInfo_.createdAt ) )
@@ -575,7 +576,7 @@ class PostgreSqlCursorPageTest {
         final var shouldBeEmpty = dataRecordRepository.loadPage( request2 );
         assertThat( shouldBeEmpty ).isNotNull();
         assertThat( shouldBeEmpty.getContent() ).isEmpty();
-        assertThat( dataRecordRepository.count( request2 ) ).isEqualTo( 0 );
+        assertThat( dataRecordRepository.count( request2 ) ).isZero();
     }
 
     @Test
@@ -645,8 +646,7 @@ class PostgreSqlCursorPageTest {
         assertThat( secondPage ).isNotNull();
         assertThat( secondPage.getContent() ).hasSize( 5 );
 
-        assertThat( reversedFirstPage ).isNotNull();
-        assertThat( reversedFirstPage ).containsExactlyElementsOf( firstPage );
+        assertThat( reversedFirstPage ).isNotNull().containsExactlyElementsOf( firstPage );
         assertThat( reversedFirstPage.next() ).isNotPresent();
     }
 

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/TestDataGenerator.java
@@ -25,8 +25,8 @@ import static io.vigier.cursorpaging.jpa.itest.model.AccessEntry.Action.WRITE;
 @Slf4j
 public class TestDataGenerator {
 
-    public static String NAME_ALPHA = "Alpha";
-    public static String NAME_BRAVO = "Bravo";
+    public static final String NAME_ALPHA = "Alpha";
+    public static final String NAME_BRAVO = "Bravo";
     public static final String[] NAMES = { NAME_ALPHA, NAME_BRAVO, "Charlie", "Delta", "Echo", "Foxtrot", "Golf",
             "Hotel", "India", "Juliett", "Kilo", "Lima", "Mike", "November", "Oscar", "Papa", "Quebec", "Romeo",
             "Sierra", "Tango", "Uniform", "Victor", "Whiskey", "X-ray", "Yankee", "Zulu" };


### PR DESCRIPTION
BREAKING API CHANGES!

- Moving static utility functions into `Filters`
- Moving conditional logic of `Filter` into own sub-classes
- Support of Rule-parameters and construction of custom `FilterRule`s in serialization
- Support of or/and-filters in serialization
- Re-design of proto3 data-model