### PR TITLE
Breaking Change: Removed extra handling of rules from `PageRequest`!

### DIFF
--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
@@ -60,12 +59,7 @@ class FromDtoMapper<E> {
                 .pageSize( request.getPageSize() )
                 .enableTotalCount( request.hasTotalCount() )
                 .totalCount( request.hasTotalCount() ? request.getTotalCount() : null ) //
-                .rules( filterRules() )
                 .build();
-    }
-
-    private List<FilterRule> filterRules() {
-        return request.getFilterRulesList().stream().map( this::filterRuleOf ).filter( Objects::nonNull ).toList();
     }
 
     private FilterRule filterRuleOf( final Cursor.Rule rule ) {
@@ -93,6 +87,8 @@ class FromDtoMapper<E> {
 
         filters.addAll( dto.getFiltersList().stream().map( this::fromFilterDto ).toList() );
         filters.addAll( dto.getFilterListsList().stream().map( this::fromFilterListDto ).toList() );
+        filters.addAll( dto.getRulesList().stream().map( this::filterRuleOf ).toList() );
+
         return switch ( dto.getType() ) {
             case AND, UNRECOGNIZED -> AndFilter.of( filters );
             case OR -> OrFilter.of( filters );

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
@@ -50,18 +50,9 @@ class ToDtoMapper<E> {
         final var builder = Cursor.PageRequest.newBuilder()
                 .addAllPositions( positions() )
                 .setPageSize( pageRequest.pageSize() )
-                .setFilters( filters() )
-                .addAllFilterRules( filterRules() );
+                .setFilters( filters() );
         pageRequest.totalCount().ifPresent( builder::setTotalCount );
         return builder.build();
-    }
-
-    private Iterable<Cursor.Rule> filterRules() {
-        return pageRequest.rules()
-                .stream()
-                .map( r -> Cursor.Rule.newBuilder().setName( r.name() ).addAllParameters( toDtoParameters( r ) )
-                        .build() )
-                .toList();
     }
 
     private List<Parameter> toDtoParameters( final FilterRule r ) {
@@ -91,6 +82,9 @@ class ToDtoMapper<E> {
                         .build() );
             } else if ( f instanceof final FilterList fl ) {
                 b.addFilterLists( toDto( fl ) );
+            } else if ( f instanceof final FilterRule fr ) {
+                b.addRules( Cursor.Rule.newBuilder().setName( fr.name() ).addAllParameters( toDtoParameters( fr ) )
+                        .build() );
             }
         } );
         return b.build();

--- a/cursorpaging-jpa-api/src/main/protobuf/pagerequest.proto
+++ b/cursorpaging-jpa-api/src/main/protobuf/pagerequest.proto
@@ -46,6 +46,7 @@ message FilterList {
   optional FilterListType type = 1;
   repeated Filter filters = 2;
   repeated FilterList filter_lists = 3;
+  repeated Rule rules = 4;
 }
 
 message Rule {

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/FilterRule.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/FilterRule.java
@@ -1,6 +1,5 @@
 package io.vigier.cursorpaging.jpa;
 
-import jakarta.persistence.criteria.Predicate;
 import java.util.List;
 import java.util.Map;
 
@@ -9,16 +8,6 @@ import java.util.Map;
  * A custom rule to filter the query.
  */
 public interface FilterRule extends QueryElement {
-
-    /**
-     * Sometimes the query-predicate must be different than the count-predicate due to the criteria API
-     *
-     * @param cqb Query, Builder and Root
-     * @return the predicate which should be applied to the where-clause
-     */
-    default Predicate toCountPredicate( final QueryBuilder cqb ) {
-        return toPredicate( cqb );
-    }
 
     @Override
     default List<Attribute> attributes() {

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
@@ -3,7 +3,6 @@ package io.vigier.cursorpaging.jpa;
 import io.vigier.cursorpaging.jpa.filter.AndFilter;
 import io.vigier.cursorpaging.jpa.filter.FilterList;
 import io.vigier.cursorpaging.jpa.filter.OrFilter;
-import jakarta.persistence.Transient;
 import jakarta.persistence.metamodel.SingularAttribute;
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -54,14 +53,6 @@ public class PageRequest<E> {
      */
     @Builder.Default
     private final FilterList filters = AndFilter.of();
-
-    /**
-     * The filter rules to apply to the query (removing results). Note that filter rules are <i>not</i> passed to the
-     * client in serialized form, and must be added every-time the cursor is deserialized.
-     */
-    @Transient
-    @Singular
-    private final List<FilterRule> rules;
 
     /**
      * The size of the page to fetch
@@ -191,22 +182,6 @@ public class PageRequest<E> {
             return this;
         }
 
-        /**
-         * Add a filter-rule (custom filter implementation) to the request. A null-value is silently ignored.
-         *
-         * @param rule the rule to be added
-         * @return the builder
-         */
-        public PageRequestBuilder<E> filterRule( @Nullable final FilterRule rule ) {
-            if ( this.rules == null ) {
-                this.rules = new ArrayList<>( 3 );
-            }
-            if ( rule != null ) {
-                this.rules.add( rule );
-            }
-            return this;
-        }
-
         private PageRequestBuilder<E> addPosition( final Position pos ) {
             if ( this.positions == null ) {
                 this.positions = new ArrayList<>( 3 );
@@ -216,15 +191,14 @@ public class PageRequest<E> {
         }
     }
 
-    public PageRequest( final List<Position> positions, final FilterList filters, final List<FilterRule> rules,
-            final int pageSize, final boolean enableTotalCount, final Long totalCount ) {
+    public PageRequest( final List<Position> positions, final FilterList filters, final int pageSize,
+            final boolean enableTotalCount, final Long totalCount ) {
         if ( positions == null || positions.isEmpty() ) {
             throw new IllegalArgumentException(
                     "Cannot create page-request, at least one order-attribute (asc/desc) for determine the position of the page start is required" );
         }
         this.positions = positions;
         this.filters = filters;
-        this.rules = rules;
         this.pageSize = pageSize;
         this.enableTotalCount = enableTotalCount;
         this.totalCount = totalCount;
@@ -257,9 +231,6 @@ public class PageRequest<E> {
         c.accept( builder );
         if ( !builder.filters$set && !filters.isEmpty() ) {
             builder.filters( filters );
-        }
-        if ( (builder.rules == null || builder.rules.isEmpty()) && !rules.isEmpty() ) {
-            builder.rules( rules );
         }
         if ( (builder.positions == null || builder.positions.isEmpty()) && !positions.isEmpty() ) {
             builder.positions( positions );
@@ -312,7 +283,6 @@ public class PageRequest<E> {
                 .pageSize( this.pageSize )
                 .totalCount( this.totalCount )
                 .filters( this.filters )
-                .rules( this.rules )
                 .enableTotalCount( this.enableTotalCount ) );
     }
 

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterList.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterList.java
@@ -9,6 +9,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.experimental.Accessors;
+import org.springframework.lang.NonNull;
 
 @Getter
 @Accessors( fluent = true )
@@ -33,7 +34,7 @@ public abstract class FilterList implements QueryElement, Iterable<QueryElement>
      * @return an Iterator.
      */
     @Override
-    public Iterator<QueryElement> iterator() {
+    public @NonNull Iterator<QueryElement> iterator() {
         return filters.iterator();
     }
 

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CursorPageRepositoryImpl.java
@@ -61,7 +61,6 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
         addPositionQuery( request, cqb );
 
         cqb.andWhere( request.filters().toPredicate( cqb ) );
-        request.rules().forEach( rule -> cqb.andWhere( rule.toPredicate( cqb ) ) );
 
         request.positions().forEach( position -> cqb.orderBy( position.attribute(), position.order() ) );
 
@@ -139,7 +138,6 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
                 entityManager );
 
         request.filters().forEach( filter -> cqb.andWhere( filter.toPredicate( cqb ) ) );
-        request.rules().forEach( rule -> cqb.andWhere( rule.toCountPredicate( cqb ) ) );
 
         return entityManager.createQuery( cqb.query() ).getSingleResult();
     }
@@ -174,7 +172,6 @@ public class CursorPageRepositoryImpl<E> implements CursorPageRepository<E> {
 
     private PageRequest<E> toNextRequest( final List<E> results, final PageRequest<E> request ) {
         if ( hasNextPage( results, request ) ) {
-            // FIXME: Only one value or last & next value?
             return request.positionOf( getLastOnPage( results, request ), getFirstOnNextPage( results, request ) );
         }
         return null;

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
@@ -57,9 +57,9 @@ class PageRequestTest {
     }
 
     @Test
-    void shouldAcceptNullAsFilterRule() {
-        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) ).filterRule( null ) );
+    void shouldAcceptNullAsFilter() {
+        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) ).filter( null ) );
 
-        assertThat( pageRequest.rules() ).isEmpty();
+        assertThat( pageRequest.filters() ).isEmpty();
     }
 }


### PR DESCRIPTION
Rules and filters where not combinable (e.g. via `Filters.and(...)`) but from the API both are `QueryElements` and eventually produce a predicate for the `CursorPageRepositoryImpl`.

The separation was done for the serialization of the cursor, but this could also be solved in another way.

Here these two concepts are now merged into "filter", where rules are just another kind of filter now.

In order to clean up code, the previous methods for rules have already been removed.