### PR TITLE
introducing an 'always' filter type 

### DIFF
--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/FromDtoMapper.java
@@ -37,7 +37,8 @@ class FromDtoMapper<E> {
             Cursor.FilterType.LIKE, FilterType.LIKE, //
             Cursor.FilterType.GE, FilterType.GREATER_THAN_OR_EQUAL_TO, //
             Cursor.FilterType.LE, FilterType.LESS_THAN_OR_EQUAL_TO, //
-            Cursor.FilterType.UNRECOGNIZED, FilterType.EQUAL_TO //
+            Cursor.FilterType.UNRECOGNIZED, FilterType.EQUAL_TO, //
+            Cursor.FilterType.ALWAYS, FilterType.ALWAYS //
     );
 
     private final Cursor.PageRequest request;

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ToDtoMapper.java
@@ -31,7 +31,8 @@ class ToDtoMapper<E> {
                 FilterType.LESS_THAN, Cursor.FilterType.LT, //
                 FilterType.LIKE, Cursor.FilterType.LIKE, //
                 FilterType.LESS_THAN_OR_EQUAL_TO, Cursor.FilterType.LE, //
-                FilterType.GREATER_THAN_OR_EQUAL_TO, Cursor.FilterType.GE //
+                FilterType.GREATER_THAN_OR_EQUAL_TO, Cursor.FilterType.GE, //
+                FilterType.ALWAYS, Cursor.FilterType.ALWAYS //
         );
         LISTTYPE_MAP = Map.of( //
                 AndFilter.class, FilterListType.AND, //

--- a/cursorpaging-jpa-api/src/main/protobuf/pagerequest.proto
+++ b/cursorpaging-jpa-api/src/main/protobuf/pagerequest.proto
@@ -22,6 +22,7 @@ enum FilterType {
   LIKE = 3;
   GE = 4; // Greater or equal
   LE = 5; // Less or equal
+  ALWAYS = 6; // Filter evaluates always to true/false
 }
 
 message Position {

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filter.java
@@ -88,7 +88,7 @@ public class Filter implements QueryElement {
 
     @Override
     public boolean isEmpty() {
-        return values.isEmpty();
+        return operation.isEmpty( this );
     }
 
     /**
@@ -97,10 +97,7 @@ public class Filter implements QueryElement {
      * @param qb the query builder
      */
     public Predicate toPredicate( final QueryBuilder qb ) {
-        if ( !values.isEmpty() ) {
-            return toFilterPredicate( qb );
-        }
-        return qb.cb().and();
+        return isEmpty() ? qb.cb().and() : toFilterPredicate( qb );
     }
 
     protected Predicate toFilterPredicate( final QueryBuilder qb ) {

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/Filters.java
@@ -254,4 +254,13 @@ public final class Filters {
     public static AndFilter and( final List<QueryElement> filters ) {
         return AndFilter.of( filters );
     }
+
+    /**
+     * Creates a filter evaluating to false, i.e. will lead to filtering all results.
+     *
+     * @return a filter when added filtering all results
+     */
+    public static Filter filterAll() {
+        return Filter.create( b -> b.always().values( false ) );
+    }
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/QueryBuilder.java
@@ -106,26 +106,34 @@ public interface QueryBuilder {
     Predicate lessThanOrEqualTo( final Attribute attribute, final Comparable<?> value );
 
 
-    Predicate isNull( Attribute attribute );
+    Predicate isNull( final Attribute attribute );
+
+    /**
+     * Evaluated always to true or false depending on the given (boolean) value
+     *
+     * @param value defines if the condition should evaluate to true or false
+     * @return a predicate evaluating to the given value
+     */
+    Predicate always( final boolean value );
 
     /**
      * Low level access to add custom filter rules.
      *
      * @param conditions the predicates to be added to the query with an AND semantic
      */
-    void andWhere( List<Predicate> conditions );
+    void andWhere( final List<Predicate> conditions );
 
     /**
      * Low level access to add custom filter rules. This method modifies the query of the builder!
      *
      * @param conditions the predicates to be added to the query with an OR semantic
      */
-    void orWhere( List<Predicate> conditions );
+    void orWhere( final List<Predicate> conditions );
 
     /**
      * Low level access to add custom filter rules. This method modifies the query of the builder!
      *
-     * @param condition
+     * @param condition predicated to be added to the query with an OR semantic
      */
     void orWhere( final Predicate condition );
 
@@ -142,6 +150,6 @@ public interface QueryBuilder {
      * @param attribute the attribute to order by
      * @param order     the order (ASC or DESC)
      */
-    void orderBy( Attribute attribute, Order order );
+    void orderBy( final Attribute attribute, final Order order );
 
 }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterBuilder.java
@@ -112,6 +112,11 @@ public class FilterBuilder {
         return this;
     }
 
+    public FilterBuilder always() {
+        this.filterType = FilterType.ALWAYS;
+        return this;
+    }
+
     public FilterBuilder values( final Comparable<?>... values ) {
         return values( Arrays.asList( values ) );
     }

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterType.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterType.java
@@ -1,6 +1,7 @@
 package io.vigier.cursorpaging.jpa.filter;
 
 import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.Filter;
 import io.vigier.cursorpaging.jpa.QueryBuilder;
 import jakarta.persistence.criteria.Predicate;
 import java.util.List;
@@ -17,9 +18,18 @@ public enum FilterType implements FilterOperation {
     LESS_THAN( FilterType::lessThan ),
     LESS_THAN_OR_EQUAL_TO( FilterType::lessThanOrEqualTo ),
     LIKE( FilterType::like ),
-    ALWAYS( FilterType::always );
+    ALWAYS( FilterType::always ) {
+        @Override
+        public boolean isEmpty( final Filter filter ) {
+            return false; // does not need values
+        }
+    };
 
     private final FilterOperation operation;
+
+    public boolean isEmpty( final Filter filter ) {
+        return filter.values().isEmpty();
+    }
 
     private static Predicate equalTo( final QueryBuilder qb, final Attribute attribute,
             final List<? extends Comparable<?>> values ) {

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterType.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/filter/FilterType.java
@@ -16,7 +16,8 @@ public enum FilterType implements FilterOperation {
     GREATER_THAN_OR_EQUAL_TO( FilterType::greaterThanOrEqualTo ),
     LESS_THAN( FilterType::lessThan ),
     LESS_THAN_OR_EQUAL_TO( FilterType::lessThanOrEqualTo ),
-    LIKE( FilterType::like );
+    LIKE( FilterType::like ),
+    ALWAYS( FilterType::always );
 
     private final FilterOperation operation;
 
@@ -75,6 +76,13 @@ public enum FilterType implements FilterOperation {
         }
         return predicates[0];
     }
+
+    private static Predicate always( final QueryBuilder queryBuilder, final Attribute attribute,
+            final List<? extends Comparable<?>> values ) {
+        final var value = !values.isEmpty() && Boolean.TRUE.equals( values.getFirst() );
+        return queryBuilder.always( value );
+    }
+
 
     @Override
     public Predicate apply( final QueryBuilder qb, final Attribute attribute,

--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/impl/CriteriaQueryBuilder.java
@@ -190,4 +190,9 @@ public class CriteriaQueryBuilder<E, R> implements QueryBuilder {
     public Predicate isNull( final Attribute attribute ) {
         return cb.isNull( attribute.path( root ) );
     }
+
+    @Override
+    public Predicate always( final boolean value ) {
+        return value ? cb.and() : cb.disjunction();
+    }
 }

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/itest/PostgreSqlCursorPageTest.java
@@ -20,7 +20,6 @@ import io.vigier.cursorpaging.jpa.itest.model.SecurityClass_;
 import io.vigier.cursorpaging.jpa.itest.model.Status;
 import io.vigier.cursorpaging.jpa.itest.model.Tag;
 import io.vigier.cursorpaging.jpa.itest.model.Tag_;
-import io.vigier.cursorpaging.jpa.itest.repository.AccessEntryRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.DataRecordRepository;
 import io.vigier.cursorpaging.jpa.itest.repository.NoTagFilterRule;
 import io.vigier.cursorpaging.jpa.itest.repository.SecurityClassRepository;
@@ -65,8 +64,6 @@ class PostgreSqlCursorPageTest {
     ApplicationContext applicationContext;
     @Autowired
     private DataRecordRepository dataRecordRepository;
-    @Autowired
-    private AccessEntryRepository accessEntryRepository;
     @Autowired
     private SecurityClassRepository securityClassRepository;
     @Autowired
@@ -1031,6 +1028,19 @@ class PostgreSqlCursorPageTest {
         if ( log.isDebugEnabled() ) {
             log.debug( message + ": {}", allRecords.content().stream().map( DataRecord::getName ).toList() );
         }
+    }
+
+    @Test
+    void shouldFilterAllResults() {
+        defaultData();
+        final var all = dataRecordRepository.findAll();
+
+        final PageRequest<DataRecord> request = PageRequest.create(
+                b -> b.pageSize( 10 ).asc( DataRecord_.id ).filter( Filters.filterAll() ).enableTotalCount( true ) );
+
+        final var firstPage = dataRecordRepository.loadPage( request );
+        assertThat( firstPage.getContent() ).isEmpty();
+        assertThat( firstPage.getTotalCount() ).isPresent().get().isEqualTo( 0L );
     }
 }
 


### PR DESCRIPTION
Could be used to add a filter avoiding any results on the returned page.

Could become handy in case a permission check on the user-authentication/access-scope fails