### PR TITLE
Make `EntityManager` optional in `RequestSerializerFactory`

### DIFF
--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactory.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactory.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.ConversionService;
 
 import static java.util.Objects.requireNonNull;
@@ -26,6 +28,7 @@ import static java.util.Objects.requireNonNull;
  */
 @Builder
 @RequiredArgsConstructor
+@Slf4j
 public class RequestSerializerFactory {
 
     @Builder.Default
@@ -37,7 +40,7 @@ public class RequestSerializerFactory {
     @Builder.Default
     private final Map<Class<?>, RequestSerializer<?>> entitySerializers = new ConcurrentHashMap<>();
 
-    private final EntityManager entityManager;
+    private final @Nullable EntityManager entityManager; // mostly in testing case null
 
     public static class RequestSerializerFactoryBuilder {
         public <T> RequestSerializerFactoryBuilder serializer( final RequestSerializer<T> s ) {
@@ -78,6 +81,7 @@ public class RequestSerializerFactory {
      * @param <T>         the entity-type
      * @return this factory
      */
+    @SuppressWarnings( "unused" )
     public <T> RequestSerializerFactory configure( final Class<T> entityClass,
             final Consumer<RequestSerializerBuilder<T>> rsb ) {
         entitySerializers.computeIfAbsent( entityClass, _ -> RequestSerializer.create( entityClass )
@@ -91,6 +95,9 @@ public class RequestSerializerFactory {
     }
 
     private AttributeResolver attributeResolver( final Class<?> entityClass ) {
+        if ( entityManager == null ) {
+            return ThrowingAttributeResolver.INSTANCE;
+        }
         return JpaMetamodelAttributeResolver.of( entityManager.getMetamodel(), entityClass );
     }
 }

--- a/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ThrowingAttributeResolver.java
+++ b/cursorpaging-jpa-api/src/main/java/io/vigier/cursorpaging/jpa/serializer/ThrowingAttributeResolver.java
@@ -1,0 +1,17 @@
+package io.vigier.cursorpaging.jpa.serializer;
+
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.AttributeResolver;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor( access = lombok.AccessLevel.PRIVATE )
+public class ThrowingAttributeResolver implements AttributeResolver {
+    public static final ThrowingAttributeResolver INSTANCE = new ThrowingAttributeResolver();
+
+    @Override
+    public Attribute resolve( final String name ) {
+        throw new SerializerException(
+                "Attribute '%s' not present in cache and no entity manager configured to resolve attributes".formatted(
+                        name ) );
+    }
+}

--- a/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactoryTest.java
+++ b/cursorpaging-jpa-api/src/test/java/io/vigier/cursorpaging/jpa/serializer/RequestSerializerFactoryTest.java
@@ -1,13 +1,18 @@
 package io.vigier.cursorpaging.jpa.serializer;
 
+import io.vigier.cursorpaging.jpa.Attribute;
+import io.vigier.cursorpaging.jpa.PageRequest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.metamodel.ManagedType;
 import jakarta.persistence.metamodel.Metamodel;
+import lombok.Data;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static io.vigier.cursorpaging.jpa.PageRequest.create;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,8 +27,9 @@ class RequestSerializerFactoryTest {
     @Mock
     private ManagedType<TestEntity> managedType;
 
+    @Data
     static class TestEntity {
-
+        private Long id;
     }
 
     @Test
@@ -49,4 +55,35 @@ class RequestSerializerFactoryTest {
         verify( metamodel ).managedType( TestEntity.class );
     }
 
+    @Test
+    void shouldNotThrowExceptionWhenAttributeIsSerializedWithNullEntityManager() {
+        final var requestSerializerFactory = RequestSerializerFactory.create( f -> f.entityManager( null ) );
+        // When
+        final var serializer = requestSerializerFactory.forEntity( TestEntity.class );
+        final PageRequest<TestEntity> request = create( r -> r.desc( Attribute.of( "id", Long.class ) ) );
+        final var deserialized = serializer.toPageRequest( serializer.toBase64( request ) );
+        // Then
+        assertNotNull( deserialized );
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAttributeIsUnknownAndEntityManagerIsNull() {
+        final Encrypter encrypter = Encrypter.getInstance();
+        final var serializer = getRequestSerializerFactory( encrypter ).forEntity( TestEntity.class );
+        final PageRequest<TestEntity> request = create( r -> r.desc( Attribute.of( "id", Long.class ) ) );
+        final var base64 = serializer.toBase64( request );
+
+        // We need a new serializer to simulate deserialization in a different context where the factory does not know about the attribute
+        final var newSerializer = getRequestSerializerFactory( encrypter ).forEntity( TestEntity.class );
+
+        // Assert
+        assertThatThrownBy( () -> newSerializer.toPageRequest( base64 ) ).isInstanceOf( SerializerException.class )
+                .hasMessageContaining(
+                        "Attribute 'id' not present in cache and no entity manager configured to resolve attributes" );
+    }
+
+    private static RequestSerializerFactory getRequestSerializerFactory( final Encrypter encrypter ) {
+        return RequestSerializerFactory.create( f -> f.entityManager( null )
+                .encrypter( encrypter ) );
+    }
 }


### PR DESCRIPTION
Fixes 273: Keep old behavior to work without `EntityManager`.

Should simplify testing.