### PR TITLE
Fixes #272: Behaviour of firstFilterWith

### DIFF
--- a/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
+++ b/cursorpaging-jpa/src/main/java/io/vigier/cursorpaging/jpa/PageRequest.java
@@ -156,7 +156,8 @@ public class PageRequest<E> {
         }
 
         public PageRequestBuilder<E> sort( final Attribute attribute, final Order order ) {
-            return addPosition( Position.create( b -> b.attribute( attribute ).order( order ) ) );
+            return addPosition( Position.create( b -> b.attribute( attribute )
+                    .order( order ) ) );
         }
 
         /**
@@ -262,7 +263,8 @@ public class PageRequest<E> {
      * @return A copy of the page-request where the total-count is removed and the enable flag is set accordingly
      */
     public PageRequest<E> withEnableTotalCount( final boolean enable ) {
-        return copy( b -> b.enableTotalCount( enable ).totalCount( null ) );
+        return copy( b -> b.enableTotalCount( enable )
+                .totalCount( null ) );
     }
 
     /**
@@ -296,7 +298,9 @@ public class PageRequest<E> {
      * @return A new {@code PageRequest} with the positions set to the values of the provided entity
      */
     public PageRequest<E> positionOf( @Nonnull final E entity, @Nonnull final E nextEntity ) {
-        return create( b -> b.positions( positions.stream().map( p -> p.positionOf( entity, nextEntity ) ).toList() )
+        return create( b -> b.positions( positions.stream()
+                        .map( p -> p.positionOf( entity, nextEntity ) )
+                        .toList() )
                 .pageSize( this.pageSize )
                 .totalCount( this.totalCount )
                 .filters( this.filters )
@@ -304,7 +308,9 @@ public class PageRequest<E> {
     }
 
     public PageRequest<E> toReversed() {
-        return copy( b -> b.positions( positions.stream().map( Position::toReversed ).toList() ) );
+        return copy( b -> b.positions( positions.stream()
+                .map( Position::toReversed )
+                .toList() ) );
     }
 
     /**
@@ -323,7 +329,8 @@ public class PageRequest<E> {
     }
 
     public boolean isReversed() {
-        return positions.getFirst().reversed();
+        return positions.getFirst()
+                .reversed();
     }
 
     /**
@@ -354,12 +361,31 @@ public class PageRequest<E> {
 
     /**
      * Returns the <b>first</b> filter found given the attribute. Probably useful for tests to verify that the request
-     * is as expected.
+     * is as expected. The search iterates through all filter-lists and will return the first {@code Filter} found (not
+     * and/or lists).
      *
      * @param attribute Attribute which should be used by the filter
-     * @return a present query-element (filter) containing the attribute or an empty optional if no filter is found
+     * @return a present {@linkplain Filter} containing the attribute or an empty optional if no filter is found
      */
-    public Optional<QueryElement> firstFilterWith( final Attribute attribute ) {
-        return firstFilterWith( ele -> ele.attributes().stream().anyMatch( a -> a.equals( attribute ) ) );
+    public Optional<Filter> firstFilterWith( final Attribute attribute ) {
+        return firstFilterWith( ele -> ele instanceof final Filter f && f.attributes()
+                .stream()
+                .anyMatch( a -> a.equals( attribute ) ) ).map( Filter.class::cast );
     }
+
+    /**
+     * Returns the <b>first</b> filter-list (and/or filter-lists) found containing directly a {@linkplain Filter} with
+     * the given attribute. Probably useful for tests.
+     *
+     * @param attribute Attribute which should be used by the filter (which is in the filter-list)
+     * @return a present filter-list containing a filter with the attribute or an empty optional if no filter-list is
+     * found
+     */
+    public Optional<FilterList> firstFilterListWith( final Attribute attribute ) {
+        return firstFilterWith( ele -> ele instanceof final FilterList fl && fl.filters()
+                .stream()
+                .anyMatch( a -> a instanceof final Filter f && f.attribute()
+                        .equals( attribute ) ) ).map( FilterList.class::cast );
+    }
+
 }

--- a/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
+++ b/cursorpaging-jpa/src/test/java/io/vigier/cursorpaging/jpa/PageRequestTest.java
@@ -1,6 +1,7 @@
 package io.vigier.cursorpaging.jpa;
 
-import io.vigier.cursorpaging.jpa.filter.AndFilter;
+import io.vigier.cursorpaging.jpa.filter.FilterType;
+import io.vigier.cursorpaging.jpa.filter.OrFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -8,6 +9,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.type;
 
 class PageRequestTest {
 
@@ -16,7 +18,8 @@ class PageRequestTest {
     @ValueSource( strings = { "  ", "\t", "\n" } )
     void shouldIgnoreEmptyFilter( final String value ) {
         final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
-                .filter( Filter.create( f -> f.attribute( Attribute.of( "test", String.class ) ).equalTo( value ) ) ) );
+                .filter( Filter.create( f -> f.attribute( Attribute.of( "test", String.class ) )
+                        .equalTo( value ) ) ) );
 
         assertThat( pageRequest.filters() ).isEmpty();
     }
@@ -24,41 +27,62 @@ class PageRequestTest {
     @Test
     void shouldAddPositionAndFilterIfValuePresent() {
         final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
-                .filter( Filters.attribute( "test", String.class ).equalTo( "value" ) ) );
+                .filter( Filters.attribute( "test", String.class )
+                        .equalTo( "value" ) ) );
 
         assertThat( pageRequest.filters() ).hasSize( 1 );
-        assertThat( pageRequest.positions() ).hasSize( 1 ).first().satisfies( p -> {
-            assertThat( p.attribute().name() ).isEqualTo( "id" );
-            assertThat( p.order() ).isEqualTo( Order.ASC );
-        } );
+        assertThat( pageRequest.positions() ).hasSize( 1 )
+                .first()
+                .satisfies( p -> {
+                    assertThat( p.attribute()
+                            .name() ).isEqualTo( "id" );
+                    assertThat( p.order() ).isEqualTo( Order.ASC );
+                } );
     }
 
     @Test
     void shouldFailWhenRequestWithoutOrder() {
-        assertThatThrownBy( () -> PageRequest.create(
-                b -> b.filter( Filters.attribute( "test", String.class ).equalTo( "value" ) ) ) ).isInstanceOf(
-                        IllegalArgumentException.class )
+        assertThatThrownBy( () -> PageRequest.create( b -> b.filter( Filters.attribute( "test", String.class )
+                .equalTo( "value" ) ) ) ).isInstanceOf( IllegalArgumentException.class )
                 .hasMessageContaining(
                         "at least one order-attribute (asc/desc) for determine the position of the page start is required" );
     }
 
     @Test
     void shouldFindFilterByAttribute() {
-        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
-                .filter( Filters.attribute( "test", String.class ).equalTo( "value" ) )
-                .filter( Filters.and( Filters.attribute( "test", String.class ).equalTo( "value2" ),
-                        Filters.attribute( "test2", String.class ).equalTo( "value3" ) ) ) );
+        final var test1Attr = Attribute.of( "test", String.class );
+        final var test2Attr = Attribute.of( "test2", String.class );
+        final var test3Attr = Attribute.of( "test3", String.class );
 
-        assertThat( pageRequest.firstFilterWith( Attribute.of( "test", String.class ) ) ).isPresent();
+        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
+                .filter( Filters.attribute( test1Attr )
+                        .equalTo( "value" ) )
+                .filter( Filters.or( Filters.attribute( test2Attr )
+                                .equalTo( "value2" ),  //
+                        Filters.attribute( test3Attr )
+                                .equalTo( "value3" ) ) ) );
+
+        assertThat( pageRequest.firstFilterWith( test1Attr ) ).isPresent();
         assertThat( pageRequest.firstFilterWith( Attribute.of( "test", Long.class ) ) ).isEmpty();
-        assertThat( pageRequest.firstFilterWith( Attribute.of( "test2", String.class ) ) ).isPresent()
+
+        assertThat( pageRequest.firstFilterWith( test3Attr ) ).isPresent()
                 .get()
-                .isInstanceOf( AndFilter.class );
+                .asInstanceOf( type( Filter.class ) )
+                .satisfies( f -> {
+                    assertThat( f.attribute() ).isEqualTo( test3Attr );
+                    assertThat( f.operation() ).isEqualTo( FilterType.EQUAL_TO );
+                } );
+
+        assertThat( pageRequest.firstFilterListWith( test3Attr ) ).isPresent()
+                .get()
+                .asInstanceOf( type( OrFilter.class ) )
+                .satisfies( f -> assertThat( f.attributes() ).contains( test2Attr, test3Attr ) );
     }
 
     @Test
     void shouldAcceptNullAsFilter() {
-        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) ).filter( null ) );
+        final var pageRequest = PageRequest.create( b -> b.asc( Attribute.of( "id", Long.class ) )
+                .filter( null ) );
 
         assertThat( pageRequest.filters() ).isEmpty();
     }


### PR DESCRIPTION
The current implementation was not useful, as it would always return the top-level list and never the concrete Filter. Modified to return the Filter instance also expressing this with method signature change. Added additional search method to return the directly containing list of the specified filter-attribute